### PR TITLE
state: rebuild the shared snapshot after a direct mutation

### DIFF
--- a/pkg/state/state.go
+++ b/pkg/state/state.go
@@ -28,6 +28,10 @@ type ClusterState struct {
 	Cache      cache.Cache
 	profiles   *upstreamsync.ProfileMap
 	sharedSnap *cache.Snapshot
+	// prev is the ClusterSnapshot returned by the previous Snapshot call. It is
+	// consulted to detect a committed direct mutation that the incremental
+	// refresh cannot undo, so the shared snapshot can be rebuilt instead.
+	prev *snapshot.ClusterSnapshot
 }
 
 // New creates a new ClusterState with an internal Kubernetes scheduler cache, frameworks,
@@ -44,9 +48,22 @@ func New(c cache.Cache, profiles *upstreamsync.ProfileMap, snap *cache.Snapshot)
 // in-place. Calling Snapshot again invalidates any previously returned ClusterSnapshot — the caller
 // must not use a previous snapshot after requesting a new one.
 func (s *ClusterState) Snapshot(logger klog.Logger) (*snapshot.ClusterSnapshot, error) {
-	snap := s.sharedSnap
-	if err := s.Cache.UpdateSnapshot(logger, snap); err != nil {
+	// If the previous snapshot committed a direct mutation of the shared
+	// snapshot (such as a PreemptPods removal), the incremental UpdateSnapshot
+	// would not restore it: that mutation does not advance the cache-side node
+	// generation, so the refresh treats the node as already in sync and skips
+	// it. Rebuild the shared snapshot from the cache in that case, keeping the
+	// same *cache.Snapshot pointer the frameworks were built with.
+	if s.prev != nil && s.prev.NeedsAuthoritativeRefresh() {
+		fresh := cache.NewEmptySnapshot()
+		if err := s.Cache.UpdateSnapshot(logger, fresh); err != nil {
+			return nil, fmt.Errorf("failed to rebuild snapshot: %w", err)
+		}
+		*s.sharedSnap = *fresh
+	} else if err := s.Cache.UpdateSnapshot(logger, s.sharedSnap); err != nil {
 		return nil, fmt.Errorf("failed to update snapshot: %w", err)
 	}
-	return snapshot.New(snap, s.profiles), nil
+	cs := snapshot.New(s.sharedSnap, s.profiles)
+	s.prev = cs
+	return cs, nil
 }

--- a/pkg/state/state_test.go
+++ b/pkg/state/state_test.go
@@ -31,10 +31,25 @@ import (
 	"sigs.k8s.io/scheduler-library/pkg/framework"
 	ft "sigs.k8s.io/scheduler-library/pkg/framework/testing"
 	"sigs.k8s.io/scheduler-library/pkg/upstreamsync"
+	"sigs.k8s.io/scheduler-library/pkg/upstreamsync/snapshot"
 )
 
 func init() {
 	framework.InitMetricsOnce()
+}
+
+// recordingCache wraps a cache.Cache and records the *cache.Snapshot passed to
+// each UpdateSnapshot call, so a test can tell an in-place incremental refresh
+// (target == the shared snapshot) from an authoritative rebuild (target == a
+// fresh snapshot).
+type recordingCache struct {
+	cache.Cache
+	updateTargets []*cache.Snapshot
+}
+
+func (c *recordingCache) UpdateSnapshot(logger klog.Logger, snap *cache.Snapshot) error {
+	c.updateTargets = append(c.updateTargets, snap)
+	return c.Cache.UpdateSnapshot(logger, snap)
 }
 
 func TestClusterState_AddPod(t *testing.T) {
@@ -478,5 +493,574 @@ func TestClusterState_SequentialUpdates(t *testing.T) {
 func newDummyProfileMap() *upstreamsync.ProfileMap {
 	return &upstreamsync.ProfileMap{
 		Map: make(profile.Map),
+	}
+}
+
+func TestClusterStateSnapshotRestoresAuthoritativeStateAfterPreemption(t *testing.T) {
+	ctx := t.Context()
+	logger := klog.FromContext(ctx)
+
+	node := st.MakeNode().Name("node1").Obj()
+	victim := st.MakePod().Name("victim").Namespace("default").UID("victim").Node("node1").Obj()
+
+	sharedSnap := cache.NewEmptySnapshot()
+	state := New(cache.New(ctx, nil, false), newDummyProfileMap(), sharedSnap)
+
+	state.Cache.AddNode(logger, node)
+	if err := state.Cache.AddPod(logger, victim); err != nil {
+		t.Fatalf("AddPod() error = %v", err)
+	}
+
+	csnap, err := state.Snapshot(logger)
+	if err != nil {
+		t.Fatalf("Snapshot() error = %v", err)
+	}
+	ft.VerifySnapshot(t, sharedSnap, map[string]sets.Set[string]{"node1": sets.New("victim")})
+
+	// PreemptPods mutates the shared snapshot in place and commits, so the victim
+	// leaves the snapshot while the authoritative cache still holds it.
+	if _, err := csnap.PreemptPods(ctx, []*v1.Pod{victim}); err != nil {
+		t.Fatalf("PreemptPods() error = %v", err)
+	}
+	ft.VerifySnapshot(t, sharedSnap, map[string]sets.Set[string]{"node1": sets.New[string]()})
+
+	// The authoritative cache must still hold the victim: only the shared
+	// snapshot diverged. This is the invariant the resync relies on, so pin it
+	// directly rather than inferring it from the victim reappearing later.
+	if cached, err := state.Cache.GetPod(victim); err != nil {
+		t.Fatalf("authoritative cache lost the victim after PreemptPods: %v", err)
+	} else if cached.UID != victim.UID {
+		t.Fatalf("cached victim UID = %q, want %q", cached.UID, victim.UID)
+	}
+
+	// A fresh ClusterState snapshot is expected to resynchronize the shared
+	// snapshot with the cache, restoring the victim.
+	if _, err := state.Snapshot(logger); err != nil {
+		t.Fatalf("Snapshot() error = %v", err)
+	}
+	ft.VerifySnapshot(t, sharedSnap, map[string]sets.Set[string]{"node1": sets.New("victim")})
+
+	// The rebuild clears the dirty flag, so later refreshes stay on the
+	// incremental path. They must keep exactly one victim rather than dropping it
+	// or compensating a second time.
+	for i := 0; i < 2; i++ {
+		if _, err := state.Snapshot(logger); err != nil {
+			t.Fatalf("Snapshot() error = %v", err)
+		}
+		ft.VerifySnapshot(t, sharedSnap, map[string]sets.Set[string]{"node1": sets.New("victim")})
+	}
+}
+
+func TestClusterStateSnapshotDoesNotLeaveEarlierMutationAfterAnotherNodeUpdate(t *testing.T) {
+	ctx := t.Context()
+	logger := klog.FromContext(ctx)
+
+	node1 := st.MakeNode().Name("node1").Obj()
+	node2 := st.MakeNode().Name("node2").Obj()
+	victim := st.MakePod().Name("victim").Namespace("default").UID("victim").Node("node1").Obj()
+
+	sharedSnap := cache.NewEmptySnapshot()
+	state := New(cache.New(ctx, nil, false), newDummyProfileMap(), sharedSnap)
+
+	state.Cache.AddNode(logger, node1)
+	state.Cache.AddNode(logger, node2)
+	if err := state.Cache.AddPod(logger, victim); err != nil {
+		t.Fatalf("AddPod() error = %v", err)
+	}
+
+	csnap, err := state.Snapshot(logger)
+	if err != nil {
+		t.Fatalf("Snapshot() error = %v", err)
+	}
+	if _, err := csnap.PreemptPods(ctx, []*v1.Pod{victim}); err != nil {
+		t.Fatalf("PreemptPods() error = %v", err)
+	}
+	ft.VerifySnapshot(t, sharedSnap, map[string]sets.Set[string]{"node1": sets.New[string](), "node2": sets.New[string]()})
+
+	// An unrelated cache update bumps only node2's cache generation. The
+	// incremental UpdateSnapshot copies node2, then stops at node1's unchanged
+	// cache-side generation, so the earlier snapshot-side removal on node1 is
+	// never undone.
+	unrelated := st.MakePod().Name("unrelated").Namespace("default").UID("unrelated").Node("node2").Obj()
+	if err := state.Cache.AddPod(logger, unrelated); err != nil {
+		t.Fatalf("AddPod() error = %v", err)
+	}
+	if _, err := state.Snapshot(logger); err != nil {
+		t.Fatalf("Snapshot() error = %v", err)
+	}
+	ft.VerifySnapshot(t, sharedSnap, map[string]sets.Set[string]{"node1": sets.New("victim"), "node2": sets.New("unrelated")})
+}
+
+func TestClusterStateSnapshotRestoresAfterCommittedTransaction(t *testing.T) {
+	ctx := t.Context()
+	logger := klog.FromContext(ctx)
+
+	sharedSnap := cache.NewEmptySnapshot()
+	state := New(cache.New(ctx, nil, false), newDummyProfileMap(), sharedSnap)
+	state.Cache.AddNode(logger, st.MakeNode().Name("node1").Obj())
+	victim := st.MakePod().Name("victim").Namespace("default").UID("victim").Node("node1").Obj()
+	if err := state.Cache.AddPod(logger, victim); err != nil {
+		t.Fatalf("AddPod() error = %v", err)
+	}
+	csnap, err := state.Snapshot(logger)
+	if err != nil {
+		t.Fatalf("Snapshot() error = %v", err)
+	}
+
+	if err := csnap.Transaction(ctx, func() (snapshot.TransactionResult, error) {
+		_, err := csnap.PreemptPods(ctx, []*v1.Pod{victim})
+		return snapshot.Commit, err
+	}); err != nil {
+		t.Fatalf("Transaction() error = %v", err)
+	}
+	ft.VerifySnapshot(t, sharedSnap, map[string]sets.Set[string]{"node1": sets.New[string]()})
+
+	if _, err := state.Snapshot(logger); err != nil {
+		t.Fatalf("Snapshot() error = %v", err)
+	}
+	ft.VerifySnapshot(t, sharedSnap, map[string]sets.Set[string]{"node1": sets.New("victim")})
+}
+
+func TestClusterStateSnapshotAfterRevertedTransaction(t *testing.T) {
+	ctx := t.Context()
+	logger := klog.FromContext(ctx)
+
+	sharedSnap := cache.NewEmptySnapshot()
+	state := New(cache.New(ctx, nil, false), newDummyProfileMap(), sharedSnap)
+	state.Cache.AddNode(logger, st.MakeNode().Name("node1").Capacity(map[v1.ResourceName]string{
+		v1.ResourceCPU:  "4",
+		v1.ResourcePods: "10",
+	}).Obj())
+	victim := st.MakePod().Name("victim").Namespace("default").UID("victim").Node("node1").
+		Req(map[v1.ResourceName]string{v1.ResourceCPU: "1"}).Obj()
+	if err := state.Cache.AddPod(logger, victim); err != nil {
+		t.Fatalf("AddPod() error = %v", err)
+	}
+	csnap, err := state.Snapshot(logger)
+	if err != nil {
+		t.Fatalf("Snapshot() error = %v", err)
+	}
+
+	// The transaction reverts, so the removal is undone and the victim is back in
+	// the snapshot before the refresh.
+	if err := csnap.Transaction(ctx, func() (snapshot.TransactionResult, error) {
+		_, err := csnap.PreemptPods(ctx, []*v1.Pod{victim})
+		return snapshot.Revert, err
+	}); err != nil {
+		t.Fatalf("Transaction() error = %v", err)
+	}
+	ft.VerifySnapshot(t, sharedSnap, map[string]sets.Set[string]{"node1": sets.New("victim")})
+
+	// The refresh keeps exactly one victim: not dropped, not double-added. Check
+	// the resource accounting too, since a double add-back would double the
+	// request while still listing the pod only once.
+	if _, err := state.Snapshot(logger); err != nil {
+		t.Fatalf("Snapshot() error = %v", err)
+	}
+	ft.VerifySnapshot(t, sharedSnap, map[string]sets.Set[string]{"node1": sets.New("victim")})
+	ni, err := sharedSnap.Get("node1")
+	if err != nil {
+		t.Fatalf("Get(node1) error = %v", err)
+	}
+	if got := ni.GetRequested().GetMilliCPU(); got != 1000 {
+		t.Fatalf("MilliCPU after revert + refresh = %d, want 1000 (double-counted or dropped)", got)
+	}
+}
+
+func TestClusterStateSnapshotAfterPreemptUnpreempt(t *testing.T) {
+	ctx := t.Context()
+	logger := klog.FromContext(ctx)
+
+	sharedSnap := cache.NewEmptySnapshot()
+	state := New(cache.New(ctx, nil, false), newDummyProfileMap(), sharedSnap)
+	state.Cache.AddNode(logger, st.MakeNode().Name("node1").Capacity(map[v1.ResourceName]string{
+		v1.ResourceCPU:  "4",
+		v1.ResourcePods: "10",
+	}).Obj())
+	victim := st.MakePod().Name("victim").Namespace("default").UID("victim").Node("node1").
+		Req(map[v1.ResourceName]string{v1.ResourceCPU: "1"}).HostPort(8080).Obj()
+	if err := state.Cache.AddPod(logger, victim); err != nil {
+		t.Fatalf("AddPod() error = %v", err)
+	}
+	csnap, err := state.Snapshot(logger)
+	if err != nil {
+		t.Fatalf("Snapshot() error = %v", err)
+	}
+
+	handle, err := csnap.PreemptPods(ctx, []*v1.Pod{victim})
+	if err != nil {
+		t.Fatalf("PreemptPods() error = %v", err)
+	}
+	ft.VerifySnapshot(t, sharedSnap, map[string]sets.Set[string]{"node1": sets.New[string]()})
+	if _, err := csnap.Unpreempt(handle); err != nil {
+		t.Fatalf("Unpreempt() error = %v", err)
+	}
+	ft.VerifySnapshot(t, sharedSnap, map[string]sets.Set[string]{"node1": sets.New("victim")})
+
+	if _, err := state.Snapshot(logger); err != nil {
+		t.Fatalf("Snapshot() error = %v", err)
+	}
+	ft.VerifySnapshot(t, sharedSnap, map[string]sets.Set[string]{"node1": sets.New("victim")})
+	// Restored exactly once: preempt subtracted the request and freed the port,
+	// unpreempt added them back, and the refresh must not compound either.
+	ni, err := sharedSnap.Get("node1")
+	if err != nil {
+		t.Fatalf("Get(node1) error = %v", err)
+	}
+	if got := ni.GetRequested().GetMilliCPU(); got != 1000 {
+		t.Fatalf("MilliCPU after preempt/unpreempt + refresh = %d, want 1000", got)
+	}
+	if got := ni.GetUsedPorts().Len(); got != 1 {
+		t.Fatalf("used ports after preempt/unpreempt + refresh = %d, want 1", got)
+	}
+}
+
+func TestClusterStateSnapshotRestoresDerivedNodeState(t *testing.T) {
+	ctx := t.Context()
+	logger := klog.FromContext(ctx)
+
+	sharedSnap := cache.NewEmptySnapshot()
+	state := New(cache.New(ctx, nil, false), newDummyProfileMap(), sharedSnap)
+	state.Cache.AddNode(logger, st.MakeNode().Name("node1").Capacity(map[v1.ResourceName]string{
+		v1.ResourceCPU:    "4",
+		v1.ResourceMemory: "8Gi",
+		v1.ResourcePods:   "10",
+	}).Obj())
+	// A state-rich victim: the fix must restore every piece of scheduler-visible
+	// state its removal unwound, not just the pod name. RemovePod rolls back
+	// resource accounting, host ports, PVC references, and the anti-affinity
+	// index, so a partial fix that only re-added the pod to Pods would pass a
+	// name-only check while leaving the node mis-accounted.
+	victim := st.MakePod().Name("victim").Namespace("default").UID("victim").Node("node1").
+		Req(map[v1.ResourceName]string{v1.ResourceCPU: "1", v1.ResourceMemory: "1Gi"}).
+		HostPort(8080).
+		PVC("victim-pvc").
+		PodAntiAffinityExists("team", "topology.kubernetes.io/zone", st.PodAntiAffinityWithRequiredReq).
+		Obj()
+	if err := state.Cache.AddPod(logger, victim); err != nil {
+		t.Fatalf("AddPod() error = %v", err)
+	}
+	csnap, err := state.Snapshot(logger)
+	if err != nil {
+		t.Fatalf("Snapshot() error = %v", err)
+	}
+
+	if _, err := csnap.PreemptPods(ctx, []*v1.Pod{victim}); err != nil {
+		t.Fatalf("PreemptPods() error = %v", err)
+	}
+	if _, err := state.Snapshot(logger); err != nil {
+		t.Fatalf("Snapshot() error = %v", err)
+	}
+
+	ni, err := sharedSnap.Get("node1")
+	if err != nil {
+		t.Fatalf("Get(node1) error = %v", err)
+	}
+	// Pod identity, not just the name.
+	pods := ni.GetPods()
+	if len(pods) != 1 {
+		t.Fatalf("restored pods = %d, want 1", len(pods))
+	}
+	if got := pods[0].GetPod().UID; got != victim.UID {
+		t.Fatalf("restored pod UID = %q, want %q", got, victim.UID)
+	}
+	// Resource accounting.
+	if got := ni.GetRequested().GetMilliCPU(); got != 1000 {
+		t.Fatalf("restored MilliCPU = %d, want 1000 (derived state not restored)", got)
+	}
+	if got := ni.GetRequested().GetMemory(); got != 1<<30 {
+		t.Fatalf("restored Memory = %d, want %d (1Gi)", got, int64(1<<30))
+	}
+	// Host ports, PVC references, and the per-node anti-affinity subset, by exact
+	// key rather than count.
+	if !ni.GetUsedPorts().CheckConflict("", "TCP", 8080) {
+		t.Fatalf("restored used ports missing 8080/TCP")
+	}
+	if got := ni.GetPVCRefCounts()["default/victim-pvc"]; got != 1 {
+		t.Fatalf("restored PVC ref count for default/victim-pvc = %d, want 1", got)
+	}
+	if got := len(ni.GetPodsWithRequiredAntiAffinity()); got != 1 {
+		t.Fatalf("restored pods with required anti-affinity = %d, want 1", got)
+	}
+	// The snapshot-wide anti-affinity index, which a per-node RemovePod does not
+	// maintain on its own: only the authoritative rebuild brings it back.
+	withAntiAffinity, err := sharedSnap.NodeInfos().HavePodsWithRequiredAntiAffinityList()
+	if err != nil {
+		t.Fatalf("HavePodsWithRequiredAntiAffinityList() error = %v", err)
+	}
+	if len(withAntiAffinity) != 1 {
+		t.Fatalf("nodes in anti-affinity index = %d, want 1", len(withAntiAffinity))
+	}
+	// Snapshot-wide PVC index.
+	if !sharedSnap.StorageInfos().IsPVCUsedByPods("default/victim-pvc") {
+		t.Fatalf("restored snapshot-wide PVC index missing default/victim-pvc")
+	}
+	ft.VerifySnapshot(t, sharedSnap, map[string]sets.Set[string]{"node1": sets.New("victim")})
+}
+
+// TestClusterStateSnapshotRefreshIsDirtyOnlyAfterDirectMutation pins the dirty
+// flag contract: a plain cache refresh leaves the snapshot clean, and only an
+// out-of-band direct mutation such as PreemptPods sets NeedsAuthoritativeRefresh.
+// It checks the flag, not which snapshot the refresh targets;
+// TestClusterStateSnapshotUsesFreshSnapshotOnlyOnRebuild pins the path itself.
+func TestClusterStateSnapshotRefreshIsDirtyOnlyAfterDirectMutation(t *testing.T) {
+	ctx := t.Context()
+	logger := klog.FromContext(ctx)
+
+	sharedSnap := cache.NewEmptySnapshot()
+	state := New(cache.New(ctx, nil, false), newDummyProfileMap(), sharedSnap)
+	state.Cache.AddNode(logger, st.MakeNode().Name("node1").Obj())
+	victim := st.MakePod().Name("victim").Namespace("default").UID("victim").Node("node1").Obj()
+	if err := state.Cache.AddPod(logger, victim); err != nil {
+		t.Fatalf("AddPod() error = %v", err)
+	}
+
+	csnap, err := state.Snapshot(logger)
+	if err != nil {
+		t.Fatalf("Snapshot() error = %v", err)
+	}
+	if csnap.NeedsAuthoritativeRefresh() {
+		t.Fatalf("a clean snapshot must not need an authoritative refresh")
+	}
+
+	// An ordinary cache update advances the cache-side generation, so the
+	// incremental refresh handles it; it must not set the dirty flag.
+	if err := state.Cache.AddPod(logger, st.MakePod().Name("other").Namespace("default").UID("other").Node("node1").Obj()); err != nil {
+		t.Fatalf("AddPod() error = %v", err)
+	}
+	csnap, err = state.Snapshot(logger)
+	if err != nil {
+		t.Fatalf("Snapshot() error = %v", err)
+	}
+	if csnap.NeedsAuthoritativeRefresh() {
+		t.Fatalf("an ordinary cache update must not need an authoritative refresh")
+	}
+
+	// A direct in-place mutation of the shared snapshot is the only thing that
+	// forces the next refresh to rebuild.
+	if _, err := csnap.PreemptPods(ctx, []*v1.Pod{victim}); err != nil {
+		t.Fatalf("PreemptPods() error = %v", err)
+	}
+	if !csnap.NeedsAuthoritativeRefresh() {
+		t.Fatalf("a committed direct mutation must need an authoritative refresh")
+	}
+}
+
+// TestClusterStateSnapshotResyncVisibleThroughFrameworkLister runs the resync
+// assertions through a real framework's SnapshotSharedLister rather than a
+// direct read of the shared snapshot. The rebuild must update the very snapshot
+// the framework was constructed with; replacing that pointer would leave plugin
+// listers looking at stale state even though a freshly returned snapshot is
+// correct.
+func TestClusterStateSnapshotResyncVisibleThroughFrameworkLister(t *testing.T) {
+	ctx := t.Context()
+	logger := klog.FromContext(ctx)
+
+	sharedSnap := cache.NewEmptySnapshot()
+	informerFactory := informers.NewSharedInformerFactory(fake.NewClientset(), 0)
+	fwk, err := frameworkruntime.NewFramework(ctx, plugins.NewInTreeRegistry(),
+		&schedulerapi.KubeSchedulerProfile{SchedulerName: "default-scheduler"},
+		frameworkruntime.WithSnapshotSharedLister(sharedSnap),
+		frameworkruntime.WithInformerFactory(informerFactory),
+	)
+	if err != nil {
+		t.Fatalf("NewFramework() error = %v", err)
+	}
+	profiles := &upstreamsync.ProfileMap{Map: profile.Map{"default-scheduler": fwk}}
+	state := New(cache.New(ctx, nil, false), profiles, sharedSnap)
+
+	state.Cache.AddNode(logger, st.MakeNode().Name("node1").Obj())
+	victim := st.MakePod().Name("victim").Namespace("default").UID("victim").Node("node1").Obj()
+	if err := state.Cache.AddPod(logger, victim); err != nil {
+		t.Fatalf("AddPod() error = %v", err)
+	}
+
+	csnap, err := state.Snapshot(logger)
+	if err != nil {
+		t.Fatalf("Snapshot() error = %v", err)
+	}
+	if _, err := csnap.PreemptPods(ctx, []*v1.Pod{victim}); err != nil {
+		t.Fatalf("PreemptPods() error = %v", err)
+	}
+	if _, err := state.Snapshot(logger); err != nil {
+		t.Fatalf("Snapshot() error = %v", err)
+	}
+
+	ni, err := fwk.SnapshotSharedLister().NodeInfos().Get("node1")
+	if err != nil {
+		t.Fatalf("framework lister Get(node1) error = %v", err)
+	}
+	pods := ni.GetPods()
+	if len(pods) != 1 || pods[0].GetPod().UID != victim.UID {
+		t.Fatalf("framework lister sees %d pods, want the victim restored", len(pods))
+	}
+}
+
+// TestClusterStateSnapshotUsesFreshSnapshotOnlyOnRebuild is the real fast-path
+// oracle: it records which *cache.Snapshot each refresh targets. Clean refreshes
+// must update the shared snapshot in place; only a refresh after a direct
+// mutation may rebuild into a fresh snapshot. An implementation that always
+// rebuilt would fail the clean-path checks, and one that never rebuilt would
+// fail the dirty-path check.
+func TestClusterStateSnapshotUsesFreshSnapshotOnlyOnRebuild(t *testing.T) {
+	ctx := t.Context()
+	logger := klog.FromContext(ctx)
+
+	sharedSnap := cache.NewEmptySnapshot()
+	rc := &recordingCache{Cache: cache.New(ctx, nil, false)}
+	state := New(rc, newDummyProfileMap(), sharedSnap)
+	state.Cache.AddNode(logger, st.MakeNode().Name("node1").Obj())
+	victim := st.MakePod().Name("victim").Namespace("default").UID("victim").Node("node1").Obj()
+	if err := state.Cache.AddPod(logger, victim); err != nil {
+		t.Fatalf("AddPod() error = %v", err)
+	}
+	lastTarget := func() *cache.Snapshot { return rc.updateTargets[len(rc.updateTargets)-1] }
+
+	_, err := state.Snapshot(logger)
+	if err != nil {
+		t.Fatalf("Snapshot() error = %v", err)
+	}
+	if lastTarget() != sharedSnap {
+		t.Fatalf("clean refresh did not update the shared snapshot in place")
+	}
+
+	if err := state.Cache.AddPod(logger, st.MakePod().Name("other").Namespace("default").UID("other").Node("node1").Obj()); err != nil {
+		t.Fatalf("AddPod() error = %v", err)
+	}
+	// Use the latest wrapper so the mutation lands on the snapshot that
+	// ClusterState will consult on the next refresh.
+	csnap, err := state.Snapshot(logger)
+	if err != nil {
+		t.Fatalf("Snapshot() error = %v", err)
+	}
+	if lastTarget() != sharedSnap {
+		t.Fatalf("ordinary cache update left the incremental path")
+	}
+
+	if _, err := csnap.PreemptPods(ctx, []*v1.Pod{victim}); err != nil {
+		t.Fatalf("PreemptPods() error = %v", err)
+	}
+	if _, err := state.Snapshot(logger); err != nil {
+		t.Fatalf("Snapshot() error = %v", err)
+	}
+	if lastTarget() == sharedSnap {
+		t.Fatalf("dirty refresh updated the shared snapshot in place instead of a fresh one")
+	}
+}
+
+// TestClusterStateSnapshotRebuildsAfterRevertedTransactionWithStalePod covers the
+// case that makes trusting the undo unsafe. The undo re-adds the caller's pod
+// object, not the one removed, so a stale object with the victim's UID but a
+// different request corrupts the accounting on revert. The next refresh must
+// rebuild from the authoritative cache rather than trust that undo.
+func TestClusterStateSnapshotRebuildsAfterRevertedTransactionWithStalePod(t *testing.T) {
+	ctx := t.Context()
+	logger := klog.FromContext(ctx)
+
+	sharedSnap := cache.NewEmptySnapshot()
+	state := New(cache.New(ctx, nil, false), newDummyProfileMap(), sharedSnap)
+	state.Cache.AddNode(logger, st.MakeNode().Name("node1").Capacity(map[v1.ResourceName]string{
+		v1.ResourceCPU:  "8",
+		v1.ResourcePods: "10",
+	}).Obj())
+	victim := st.MakePod().Name("victim").Namespace("default").UID("victim").Node("node1").
+		Req(map[v1.ResourceName]string{v1.ResourceCPU: "1"}).Obj()
+	if err := state.Cache.AddPod(logger, victim); err != nil {
+		t.Fatalf("AddPod() error = %v", err)
+	}
+	csnap, err := state.Snapshot(logger)
+	if err != nil {
+		t.Fatalf("Snapshot() error = %v", err)
+	}
+
+	// Same UID as the authoritative victim, different request. RemovePod matches
+	// by UID and subtracts the real 1 CPU; the undo re-adds this stale 2 CPU.
+	stale := st.MakePod().Name("victim").Namespace("default").UID("victim").Node("node1").
+		Req(map[v1.ResourceName]string{v1.ResourceCPU: "2"}).Obj()
+	if err := csnap.Transaction(ctx, func() (snapshot.TransactionResult, error) {
+		_, err := csnap.PreemptPods(ctx, []*v1.Pod{stale})
+		return snapshot.Revert, err
+	}); err != nil {
+		t.Fatalf("Transaction() error = %v", err)
+	}
+	if !csnap.NeedsAuthoritativeRefresh() {
+		t.Fatalf("a reverted preemption must still request an authoritative refresh")
+	}
+
+	if _, err := state.Snapshot(logger); err != nil {
+		t.Fatalf("Snapshot() error = %v", err)
+	}
+	ni, err := sharedSnap.Get("node1")
+	if err != nil {
+		t.Fatalf("Get(node1) error = %v", err)
+	}
+	if got := ni.GetRequested().GetMilliCPU(); got != 1000 {
+		t.Fatalf("MilliCPU after reverted stale preemption = %d, want 1000 (authoritative 1 CPU, not the stale 2)", got)
+	}
+}
+
+// TestClusterStateSnapshotRebuildsAfterPartialPreemptionFailure covers the error
+// path: one removal succeeds, the next fails, and the call rolls back. The
+// mutation still happened, so the flag must be set despite the returned error.
+func TestClusterStateSnapshotRebuildsAfterPartialPreemptionFailure(t *testing.T) {
+	ctx := t.Context()
+	logger := klog.FromContext(ctx)
+
+	sharedSnap := cache.NewEmptySnapshot()
+	state := New(cache.New(ctx, nil, false), newDummyProfileMap(), sharedSnap)
+	state.Cache.AddNode(logger, st.MakeNode().Name("node1").Capacity(map[v1.ResourceName]string{
+		v1.ResourceCPU:  "8",
+		v1.ResourcePods: "10",
+	}).Obj())
+	victim := st.MakePod().Name("victim").Namespace("default").UID("victim").Node("node1").
+		Req(map[v1.ResourceName]string{v1.ResourceCPU: "1"}).Obj()
+	if err := state.Cache.AddPod(logger, victim); err != nil {
+		t.Fatalf("AddPod() error = %v", err)
+	}
+	csnap, err := state.Snapshot(logger)
+	if err != nil {
+		t.Fatalf("Snapshot() error = %v", err)
+	}
+
+	// The second pod is not in the snapshot, so its removal fails after the first
+	// succeeds and the call rolls back with an error.
+	missing := st.MakePod().Name("missing").Namespace("default").UID("missing").Node("node1").Obj()
+	if _, err := csnap.PreemptPods(ctx, []*v1.Pod{victim, missing}); err == nil {
+		t.Fatalf("PreemptPods() with a missing pod: want error, got nil")
+	}
+	if !csnap.NeedsAuthoritativeRefresh() {
+		t.Fatalf("a rolled-back partial preemption must still request an authoritative refresh")
+	}
+
+	if _, err := state.Snapshot(logger); err != nil {
+		t.Fatalf("Snapshot() error = %v", err)
+	}
+	ni, err := sharedSnap.Get("node1")
+	if err != nil {
+		t.Fatalf("Get(node1) error = %v", err)
+	}
+	if got := ni.GetRequested().GetMilliCPU(); got != 1000 {
+		t.Fatalf("MilliCPU after rolled-back partial preemption = %d, want 1000", got)
+	}
+}
+
+// TestClusterStateSnapshotEmptyPreemptionStaysClean checks that a preemption that
+// removes nothing does not force a rebuild.
+func TestClusterStateSnapshotEmptyPreemptionStaysClean(t *testing.T) {
+	ctx := t.Context()
+	logger := klog.FromContext(ctx)
+
+	sharedSnap := cache.NewEmptySnapshot()
+	state := New(cache.New(ctx, nil, false), newDummyProfileMap(), sharedSnap)
+	state.Cache.AddNode(logger, st.MakeNode().Name("node1").Obj())
+	csnap, err := state.Snapshot(logger)
+	if err != nil {
+		t.Fatalf("Snapshot() error = %v", err)
+	}
+	if _, err := csnap.PreemptPods(ctx, nil); err != nil {
+		t.Fatalf("PreemptPods(nil) error = %v", err)
+	}
+	if csnap.NeedsAuthoritativeRefresh() {
+		t.Fatalf("an empty preemption must not request an authoritative refresh")
 	}
 }

--- a/pkg/upstreamsync/snapshot/snapshot.go
+++ b/pkg/upstreamsync/snapshot/snapshot.go
@@ -54,6 +54,10 @@ type ClusterSnapshot struct {
 	// handles unusable, i.e. whenever the state they would be restoring into is no longer the one
 	// they were taken from. Unpreempt compares it with the value recorded in the handle.
 	stateVersionForPreemption uint64
+	// needsAuthoritativeRefresh records that a PreemptPods removal may have mutated
+	// the shared snapshot. The undo is not exact, so the next Snapshot must rebuild
+	// from the cache rather than refresh incrementally.
+	needsAuthoritativeRefresh bool
 }
 
 // undoLog is a stack of the operations reverting the mutations applied to the snapshot, most
@@ -115,6 +119,14 @@ func New(s *cache.Snapshot, profiles *upstreamsync.ProfileMap) *ClusterSnapshot 
 	}
 }
 
+// NeedsAuthoritativeRefresh reports whether this snapshot may have had a direct
+// mutation applied (such as a PreemptPods removal) that a later incremental
+// Cache.UpdateSnapshot cannot reconcile on its own, because that mutation does
+// not advance the cache-side node generation the refresh compares against.
+func (s *ClusterSnapshot) NeedsAuthoritativeRefresh() bool {
+	return s.needsAuthoritativeRefresh
+}
+
 // Transaction executes the provided function within a transaction.
 // It rolls back operations if the function returns Revert or an error.
 // Only a single active transaction is supported at any given time;
@@ -137,6 +149,9 @@ func (s *ClusterSnapshot) Transaction(ctx context.Context, transactionFn func() 
 		s.undoLog.restoreState(initialStateVersion)
 		s.stateVersionForPreemption = initialStateVersionForPreemption
 	} else {
+		// A direct mutation marks the snapshot itself (see PreemptPods); the
+		// transaction does not infer it from undo-log activity, so a committed
+		// scheduling transaction stays on the incremental fast path.
 		s.undoLog.commit()
 		// invalidate preemptions done within the transaction
 		s.stateVersionForPreemption++
@@ -314,6 +329,16 @@ func (s *ClusterSnapshot) PreemptPods(ctx context.Context, pods []*v1.Pod) (_ *U
 		if pod.Spec.NodeName == "" {
 			return nil, fmt.Errorf("pod %s has no node name", klog.KObj(pod))
 		}
+	}
+
+	// A non-empty preemption is about to mutate the shared snapshot directly.
+	// Mark it now, before the first removal, so the flag holds across a later
+	// commit, revert, or error: the undo path is not an exact restoration, so any
+	// of those outcomes still needs the next ClusterState refresh to rebuild from
+	// the authoritative cache. An empty preemption mutates nothing and stays on
+	// the incremental fast path.
+	if len(pods) > 0 {
+		s.needsAuthoritativeRefresh = true
 	}
 
 	initialStateVersion := s.undoLog.stateVersion

--- a/pkg/upstreamsync/snapshot/snapshot_test.go
+++ b/pkg/upstreamsync/snapshot/snapshot_test.go
@@ -825,6 +825,36 @@ func TestSchedulePods(t *testing.T) {
 	}
 }
 
+// TestScheduleTransactionDoesNotRequestAuthoritativeRefresh checks that a
+// committed scheduling transaction stays on the incremental fast path.
+// SchedulePods registers undo operations, but its assumed-pod state is
+// reconciled by the next incremental refresh, so a committed scheduling
+// transaction must not be treated as a direct snapshot mutation the way
+// PreemptPods is.
+func TestScheduleTransactionDoesNotRequestAuthoritativeRefresh(t *testing.T) {
+	ctx := context.Background()
+	node1 := st.MakeNode().Name("node1").Capacity(map[v1.ResourceName]string{v1.ResourcePods: "2"}).Obj()
+	cs, _, _ := setupSnapshotTest(t, ctx, []*v1.Node{node1}, nil)
+	pod1 := st.MakePod().Name("pod1").Namespace("default").UID("uid-pod1").Obj()
+
+	placement, err := cs.MakePlacement([]string{"node1"})
+	if err != nil {
+		t.Fatalf("MakePlacement() error = %v", err)
+	}
+
+	err = cs.Transaction(ctx, func() (TransactionResult, error) {
+		_, err := cs.SchedulePods(ctx, []*v1.Pod{pod1}, placement, SchedulePodsOptions{})
+		return Commit, err
+	})
+	if err != nil {
+		t.Fatalf("Transaction() error = %v", err)
+	}
+
+	if cs.NeedsAuthoritativeRefresh() {
+		t.Fatalf("a committed scheduling transaction must not request an authoritative refresh")
+	}
+}
+
 func TestSchedulePodsByTemplate(t *testing.T) {
 	node1 := st.MakeNode().Name("node1").Capacity(map[v1.ResourceName]string{v1.ResourcePods: "3"}).Obj()
 


### PR DESCRIPTION
#### What type of PR is this?

/kind bug

#### What this PR does / why we need it:

`ClusterState.Snapshot()` reuses the shared `*cache.Snapshot` and refreshes it with `Cache.UpdateSnapshot()`, which only recopies a node when its cache-side generation is newer than the snapshot's watermark. `PreemptPods()` mutates a snapshot-side `NodeInfo` directly. That advances the snapshot-side `NodeInfo`'s generation, but it leaves the authoritative cache-side generation and the watermark unchanged, so the next incremental refresh treats the node as already in sync and skips it. The simulated removal survives in the shared snapshot even though the cache still holds the pod.

`ClusterSnapshot` now records when a direct mutation may have been applied. It marks the snapshot before the first removal, so the marker survives a later commit, revert, or error: the undo path is not an exact restoration (its revert re-adds the caller's pod object rather than the one removed, and a failed revert is only logged), so any of those outcomes still needs an authoritative refresh. `ClusterState` then rebuilds the shared snapshot from the cache on the next `Snapshot()`, keeping the same `*cache.Snapshot` pointer the frameworks were built with. Scheduling transactions are not marked (their assumed-pod state is reconciled incrementally), and clean refreshes keep the incremental fast path.

The regression tests cover the direct refresh; an unrelated newer node appearing first in the update order; committed, reverted, and stale-pod reverted transactions; a rolled-back partial preemption; preempt then unpreempt; an empty preemption and a committed scheduling transaction both staying on the incremental path; the exact snapshot each refresh targets (the shared one on the fast path, a fresh one on a rebuild); restoration of derived node state (resource accounting, host ports, PVC references, and the anti-affinity index, not just pod names); the authoritative cache still holding the victim; idempotent repeated refreshes; and a case that runs the assertions through a real framework's `SnapshotSharedLister`.

This restores the `ClusterState` incremental-reuse contract. The broader mutable-snapshot rework tracked in kubernetes/kubernetes#140181 may later replace this with an undo-log approach; this is a self-contained fix in the meantime, and I'm glad to align it with that direction.

#### Which issue(s) this PR fixes:

Fixes #4

#### Does this PR introduce a user-facing change?

```release-note
NONE
```
