### PR TITLE
snapshot: report undo failures and invalidate handles on rollback failure

### DIFF
--- a/pkg/upstreamsync/snapshot/helpers.go
+++ b/pkg/upstreamsync/snapshot/helpers.go
@@ -28,7 +28,7 @@ import (
 )
 
 // addPodToNode adds a new pod to the specific node and returns the corresponding revert function
-func addPodToNode(ctx context.Context, schedulerSnapshot *upstreamsync.MutatingSnapshot, pod *v1.Pod, nodeName string) (func(), error) {
+func addPodToNode(ctx context.Context, schedulerSnapshot *upstreamsync.MutatingSnapshot, pod *v1.Pod, nodeName string) (func() error, error) {
 	logger := klog.FromContext(ctx)
 	clonedPod := pod.DeepCopy()
 	clonedPod.Spec.NodeName = nodeName
@@ -41,17 +41,16 @@ func addPodToNode(ctx context.Context, schedulerSnapshot *upstreamsync.MutatingS
 		return nil, fmt.Errorf("failed to add pod to snapshot: %w", err)
 	}
 
-	revertFn := func() {
-		if _, err := removePodFromNode(ctx, schedulerSnapshot, podInfo.Pod); err != nil {
-			logger.Error(err, "revert addPodToNode failed")
-		}
+	revertFn := func() error {
+		_, err := removePodFromNode(ctx, schedulerSnapshot, podInfo.Pod)
+		return err
 	}
 
 	return revertFn, nil
 }
 
 // removePodFromNode removes a pod from a specific node and returns the corresponding revert function.
-func removePodFromNode(ctx context.Context, schedulerSnapshot *upstreamsync.MutatingSnapshot, pod *v1.Pod) (func(), error) {
+func removePodFromNode(ctx context.Context, schedulerSnapshot *upstreamsync.MutatingSnapshot, pod *v1.Pod) (func() error, error) {
 	logger := klog.FromContext(ctx)
 	podInfo, err := framework.NewPodInfo(pod.DeepCopy())
 	if err != nil {
@@ -62,10 +61,11 @@ func removePodFromNode(ctx context.Context, schedulerSnapshot *upstreamsync.Muta
 		return nil, fmt.Errorf("failed to remove pod from snapshot: %w", err)
 	}
 
-	revertFn := func() {
-		if _, err := addPodToNode(ctx, schedulerSnapshot, pod, pod.Spec.NodeName); err != nil {
-			logger.Error(err, "revert removePodFromNode failed")
-		}
+	// Restore from the copy taken at removal time, not the caller's pod, which the
+	// caller may mutate before the revert runs.
+	revertFn := func() error {
+		_, err := addPodToNode(ctx, schedulerSnapshot, podInfo.Pod, podInfo.Pod.Spec.NodeName)
+		return err
 	}
 
 	return revertFn, nil

--- a/pkg/upstreamsync/snapshot/helpers_test.go
+++ b/pkg/upstreamsync/snapshot/helpers_test.go
@@ -111,7 +111,9 @@ func TestAddPodToNode(t *testing.T) {
 			}
 
 			// Run revert function
-			revertFn()
+			if err := revertFn(); err != nil {
+				t.Fatalf("revert failed: %v", err)
+			}
 
 			nodeInfo, err = snapshot.Get(tc.targetNode)
 			if err != nil {
@@ -210,7 +212,9 @@ func TestRemovePodFromNode(t *testing.T) {
 			}
 
 			// Run revert function
-			revertFn()
+			if err := revertFn(); err != nil {
+				t.Fatalf("revert failed: %v", err)
+			}
 
 			nodeInfo, err = snapshot.Get(tc.targetNode)
 			if err != nil {

--- a/pkg/upstreamsync/snapshot/snapshot.go
+++ b/pkg/upstreamsync/snapshot/snapshot.go
@@ -37,6 +37,12 @@ import (
 // updates that shared snapshot in-place, which invalidates any previously returned
 // ClusterSnapshot instance — callers must not use a prior snapshot after requesting a new one.
 // A ClusterSnapshot is not safe for concurrent use.
+//
+// When a mutating method reports a failed rollback, the snapshot may be left partly
+// mutated and must not be reused; the failed revert can leave plugin state that cannot
+// be selectively undone. To recover, rebuild the snapshot and its plugins: for a
+// ClusterState-backed snapshot, recreate the ClusterState, which rebuilds them from the
+// unaffected cache.
 type ClusterSnapshot struct {
 	// profiles holds the scheduling framework per scheduler name. All of them share
 	// schedulerSnapshot as their SnapshotSharedLister, so the plugins always see the mutations
@@ -61,7 +67,7 @@ type ClusterSnapshot struct {
 // running them until the recorded state version is reached again.
 type undoLog struct {
 	// undoOperations are the revert functions, in the order their mutations were applied.
-	undoOperations []func()
+	undoOperations []func() error
 	// stateVersion is incremented by every registered operation and decremented by every undone
 	// one. A caller records it before mutating and passes it to restoreState afterwards to undo
 	// exactly its own mutations.
@@ -71,28 +77,39 @@ type undoLog struct {
 // registerOperation pushes the revert function of a mutation that has just been applied.
 // A nil undoOperation is ignored, so that callers can pass the result of an operation that
 // did not change anything.
-func (ul *undoLog) registerOperation(undoOperation func()) {
+func (ul *undoLog) registerOperation(undoOperation func() error) {
 	if undoOperation != nil {
 		ul.undoOperations = append(ul.undoOperations, undoOperation)
 		ul.stateVersion++
 	}
 }
 
-// restoreState undoes the operations registered after the given state version was observed,
-// in the reverse order of their registration.
-func (ul *undoLog) restoreState(stateVersion uint64) {
-	for ul.stateVersion != stateVersion {
-		ul.undo()
+// restoreState unwinds back to stateVersion, running every remaining undo even if
+// one fails and joining their errors. A target the log cannot reach is rejected
+// rather than unwound past the retained history into a slice panic.
+func (ul *undoLog) restoreState(stateVersion uint64) error {
+	if stateVersion > ul.stateVersion {
+		return fmt.Errorf("cannot restore to future state version %d from %d", stateVersion, ul.stateVersion)
 	}
+	if ul.stateVersion-stateVersion > uint64(len(ul.undoOperations)) {
+		return fmt.Errorf("cannot restore to state version %d: only %d undo operations retained", stateVersion, len(ul.undoOperations))
+	}
+	var errs []error
+	for ul.stateVersion != stateVersion {
+		if err := ul.undo(); err != nil {
+			errs = append(errs, err)
+		}
+	}
+	return errors.Join(errs...)
 }
 
 // undo pops the most recently registered operation and runs it.
-func (ul *undoLog) undo() {
+func (ul *undoLog) undo() error {
 	ops := ul.undoOperations
 	ops, undoOp := ops[:len(ops)-1], ops[len(ops)-1]
 	ul.undoOperations = ops
-	undoOp()
 	ul.stateVersion--
+	return undoOp()
 }
 
 // New creates a new ClusterSnapshot stub wrapping the provided scheduler snapshot and frameworks.
@@ -115,7 +132,11 @@ func (s *ClusterSnapshot) ResetMutations() error {
 		return fmt.Errorf("transaction is in progress, cannot reset mutations")
 	}
 	if s.undoLog.stateVersion > 0 {
-		s.undoLog.restoreState(0)
+		if err := s.undoLog.restoreState(0); err != nil {
+			// The reset left the snapshot partly mutated; invalidate outstanding handles.
+			s.stateVersionForPreemption++
+			return fmt.Errorf("reset mutations failed, snapshot may be inconsistent: %w", err)
+		}
 		s.stateVersionForPreemption++
 	}
 	return nil
@@ -142,7 +163,13 @@ func (s *ClusterSnapshot) Transaction(ctx context.Context, transactionFn func() 
 	result, err := transactionFn()
 
 	if err != nil || result == Revert {
-		s.undoLog.restoreState(initialStateVersion)
+		restoreErr := s.undoLog.restoreState(initialStateVersion)
+		if restoreErr != nil {
+			// The rollback left the snapshot partly mutated; advance the version so
+			// handles from before the transaction cannot revalidate against it.
+			s.stateVersionForPreemption++
+			return fmt.Errorf("transaction rollback failed, snapshot may be inconsistent: %w", errors.Join(err, restoreErr))
+		}
 		s.stateVersionForPreemption = initialStateVersionForPreemption
 	} else {
 		// invalidate preemptions done within the transaction
@@ -247,7 +274,11 @@ func (s *ClusterSnapshot) schedulePods(ctx context.Context, pods iter.Seq[*v1.Po
 
 	defer func() {
 		if err != nil || opts.DryRun {
-			s.undoLog.restoreState(initialStateVersion)
+			if restoreErr := s.undoLog.restoreState(initialStateVersion); restoreErr != nil {
+				// The rollback left the snapshot partly mutated; invalidate outstanding handles.
+				s.stateVersionForPreemption++
+				err = errors.Join(err, fmt.Errorf("rollback failed, snapshot may be inconsistent: %w", restoreErr))
+			}
 		}
 		if initialStateVersion != s.undoLog.stateVersion {
 			s.stateVersionForPreemption++
@@ -279,7 +310,9 @@ func (s *ClusterSnapshot) schedulePods(ctx context.Context, pods iter.Seq[*v1.Po
 		}
 
 		if revertFn != nil {
-			s.undoLog.registerOperation(revertFn)
+			// The extracted upstream revert logs its ForgetPod error and its Unreserve
+			// hook has none, so this wrapper can only ever surface nil.
+			s.undoLog.registerOperation(func() error { revertFn(); return nil })
 		}
 		result = append(result, schedulingResult(res))
 
@@ -324,7 +357,11 @@ func (s *ClusterSnapshot) PreemptPods(ctx context.Context, pods []*v1.Pod) (_ *U
 
 	defer func() {
 		if err != nil {
-			s.undoLog.restoreState(initialStateVersion)
+			if restoreErr := s.undoLog.restoreState(initialStateVersion); restoreErr != nil {
+				// The rollback left the snapshot partly mutated; invalidate outstanding handles.
+				s.stateVersionForPreemption++
+				err = errors.Join(err, fmt.Errorf("rollback failed, snapshot may be inconsistent: %w", restoreErr))
+			}
 		}
 	}()
 
@@ -333,7 +370,9 @@ func (s *ClusterSnapshot) PreemptPods(ctx context.Context, pods []*v1.Pod) (_ *U
 	unpreemptFns := []func() error{}
 
 	for _, pod := range pods {
-		revertFn, err := removePodFromNode(ctx, mutatingSnapshot, pod)
+		// Work from a copy taken now; the caller may mutate pod before a revert runs.
+		podCopy := pod.DeepCopy()
+		revertFn, err := removePodFromNode(ctx, mutatingSnapshot, podCopy)
 		if err != nil {
 			return nil, fmt.Errorf("failed to unreserve and forget pod %s: %w", klog.KObj(pod), err)
 		}
@@ -341,7 +380,7 @@ func (s *ClusterSnapshot) PreemptPods(ctx context.Context, pods []*v1.Pod) (_ *U
 		// Putting the pod back is a snapshot mutation like any other, so it goes through
 		// addPodToNode and registers its own revert function, undoing it re-preempts the pod.
 		unpreemptFns = append(unpreemptFns, func() error {
-			repreemptFn, err := addPodToNode(ctx, mutatingSnapshot, pod, pod.Spec.NodeName)
+			repreemptFn, err := addPodToNode(ctx, mutatingSnapshot, podCopy, podCopy.Spec.NodeName)
 			if err != nil {
 				return fmt.Errorf("failed to unpreempt pod %s: %w", klog.KObj(pod), err)
 			}
@@ -375,6 +414,9 @@ func (s *ClusterSnapshot) Unpreempt(u *Unpreemption) ([]*v1.Pod, error) {
 	if u == nil {
 		return nil, fmt.Errorf("preemption handle is nil")
 	}
+	if u.revertFn == nil {
+		return nil, fmt.Errorf("preemption handle is invalid: uninitialized handle")
+	}
 	if s.stateVersionForPreemption != u.validPreemptionVersion {
 		return nil, fmt.Errorf("preemption handle is invalid: snapshot has been permanently mutated since preemption")
 	}
@@ -386,10 +428,10 @@ func (s *ClusterSnapshot) Unpreempt(u *Unpreemption) ([]*v1.Pod, error) {
 		u.reverted = true
 	}()
 
-	err := u.revertFn()
-	if err != nil {
-		return nil, err
+	if err := u.revertFn(); err != nil {
+		// The revert left the snapshot partly mutated; invalidate any sibling handles.
+		s.stateVersionForPreemption++
+		return nil, fmt.Errorf("unpreempt did not fully restore the snapshot, it may be inconsistent: %w", err)
 	}
-
 	return u.pods, nil
 }

--- a/pkg/upstreamsync/snapshot/undolog_error_test.go
+++ b/pkg/upstreamsync/snapshot/undolog_error_test.go
@@ -1,0 +1,202 @@
+// Copyright The Kubernetes Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package snapshot
+
+import (
+	"context"
+	"errors"
+	"slices"
+	"strings"
+	"testing"
+
+	v1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/util/sets"
+	"k8s.io/kubernetes/pkg/scheduler/backend/cache"
+	st "k8s.io/kubernetes/pkg/scheduler/testing"
+	ft "sigs.k8s.io/scheduler-library/pkg/framework/testing"
+)
+
+func TestUndoLogRestoreStatePropagatesError(t *testing.T) {
+	boomB := errors.New("boom-b")
+	boomC := errors.New("boom-c")
+	var ul undoLog
+	var order []string
+	ul.registerOperation(func() error { order = append(order, "a"); return nil })
+	ul.registerOperation(func() error { order = append(order, "b"); return boomB })
+	ul.registerOperation(func() error { order = append(order, "c"); return boomC })
+
+	err := ul.restoreState(0)
+	// Both failures are preserved and discoverable with errors.Is.
+	if !errors.Is(err, boomB) || !errors.Is(err, boomC) {
+		t.Fatalf("restoreState should join every undo error, got %v", err)
+	}
+	// Every undo still runs, in LIFO order, even though two failed.
+	if want := []string{"c", "b", "a"}; !slices.Equal(order, want) {
+		t.Fatalf("undo order = %v, want %v", order, want)
+	}
+	if ul.stateVersion != 0 {
+		t.Fatalf("stateVersion = %d, want 0 after unwinding every operation", ul.stateVersion)
+	}
+}
+
+func TestUndoLogRestoreStateToNonZeroTarget(t *testing.T) {
+	boomC := errors.New("boom-c")
+	var ul undoLog
+	var order []string
+	ul.registerOperation(func() error { order = append(order, "a"); return nil })
+	ul.registerOperation(func() error { order = append(order, "b"); return nil })
+	ul.registerOperation(func() error { order = append(order, "c"); return boomC })
+
+	// Unwind only back to version 1; the failing "c" is still surfaced.
+	if err := ul.restoreState(1); !errors.Is(err, boomC) {
+		t.Fatalf("restoreState(1) should surface boom-c, got %v", err)
+	}
+	if want := []string{"c", "b"}; !slices.Equal(order, want) {
+		t.Fatalf("undo order = %v, want %v", order, want)
+	}
+	if ul.stateVersion != 1 {
+		t.Fatalf("stateVersion = %d, want 1", ul.stateVersion)
+	}
+}
+
+func TestUndoLogRestoreStateRejectsUnreachableTarget(t *testing.T) {
+	var ul undoLog
+	ul.registerOperation(func() error { return nil })
+
+	// A future version cannot be reached and must not run undo on an empty log.
+	if err := ul.restoreState(5); err == nil {
+		t.Fatal("restoreState to a future version should return an error, not panic")
+	}
+	// If the retained history is ever shorter than the version counter, an old target
+	// must be rejected rather than unwound into a slice panic.
+	ul.undoOperations = nil
+	if err := ul.restoreState(0); err == nil {
+		t.Fatal("restoreState past retained history should return an error, not panic")
+	}
+}
+
+func TestTransactionSurfacesRollbackError(t *testing.T) {
+	undoBoom := errors.New("undo-boom")
+	cs := New(cache.NewEmptySnapshot(), nil)
+	err := cs.Transaction(context.Background(), func() (TransactionResult, error) {
+		cs.undoLog.registerOperation(func() error { return undoBoom })
+		return Revert, nil
+	})
+	if !errors.Is(err, undoBoom) {
+		t.Fatalf("Transaction should surface a failed rollback via errors.Is, got %v", err)
+	}
+}
+
+func TestUnpreemptSurfacesRevertError(t *testing.T) {
+	revertBoom := errors.New("revert-boom")
+	cs := New(cache.NewEmptySnapshot(), nil)
+	u := &Unpreemption{
+		revertFn:               func() error { return revertBoom },
+		validPreemptionVersion: cs.stateVersionForPreemption,
+	}
+	if _, err := cs.Unpreempt(u); !errors.Is(err, revertBoom) {
+		t.Fatalf("Unpreempt should surface a failed revert via errors.Is, got %v", err)
+	}
+}
+
+func TestResetMutationsSurfacesRestoreError(t *testing.T) {
+	undoBoom := errors.New("undo-boom")
+	cs := New(cache.NewEmptySnapshot(), nil)
+	cs.undoLog.registerOperation(func() error { return undoBoom })
+
+	before := cs.stateVersionForPreemption
+	if err := cs.ResetMutations(); !errors.Is(err, undoBoom) {
+		t.Fatalf("ResetMutations should surface a failed reset via errors.Is, got %v", err)
+	}
+	// A failed reset leaves the snapshot inconsistent, so outstanding handles must be invalidated.
+	if cs.stateVersionForPreemption == before {
+		t.Fatal("ResetMutations should advance the preemption version after a failed reset")
+	}
+}
+
+func TestUnpreemptRejectsUninitializedHandle(t *testing.T) {
+	cs := New(cache.NewEmptySnapshot(), nil)
+	// A zero-value handle validates against a fresh snapshot's version 0, so it must be
+	// rejected on its nil revert rather than dereferencing it.
+	if _, err := cs.Unpreempt(&Unpreemption{}); err == nil {
+		t.Fatal("Unpreempt of an uninitialized handle should return an error, not panic")
+	}
+}
+
+func TestPreemptPodsPartialRemovalFailureRollsBack(t *testing.T) {
+	ctx := context.Background()
+	node1 := st.MakeNode().Name("node1").Capacity(map[v1.ResourceName]string{v1.ResourcePods: "10"}).Obj()
+	pod1 := st.MakePod().Name("pod1").Namespace("default").UID("uid-pod1").Node("node1").Obj()
+	// ghost has a valid node name but is absent from the snapshot, so it clears the
+	// up-front validation and fails during removal, forcing a rollback of pod1.
+	ghost := st.MakePod().Name("ghost").Namespace("default").UID("uid-ghost").Node("node1").Obj()
+
+	cs, snap, _ := setupSnapshotTest(t, ctx, []*v1.Node{node1}, []*v1.Pod{pod1})
+
+	if _, err := cs.PreemptPods(ctx, []*v1.Pod{pod1, ghost}); err == nil {
+		t.Fatal("PreemptPods should fail when a pod is missing from the snapshot")
+	}
+	ft.VerifySnapshot(t, snap, map[string]sets.Set[string]{"node1": sets.New("pod1")})
+}
+
+func TestPreemptPodsRevertUsesRemovalTimeCopy(t *testing.T) {
+	ctx := context.Background()
+	node1 := st.MakeNode().Name("node1").Capacity(map[v1.ResourceName]string{v1.ResourcePods: "10"}).Obj()
+	node2 := st.MakeNode().Name("node2").Capacity(map[v1.ResourceName]string{v1.ResourcePods: "10"}).Obj()
+	pod1 := st.MakePod().Name("pod1").Namespace("default").UID("uid-pod1").Node("node1").Obj()
+
+	cs, snap, _ := setupSnapshotTest(t, ctx, []*v1.Node{node1, node2}, []*v1.Pod{pod1})
+
+	victim := pod1.DeepCopy()
+	handle, err := cs.PreemptPods(ctx, []*v1.Pod{victim})
+	if err != nil {
+		t.Fatalf("PreemptPods: %v", err)
+	}
+	// The caller mutates its pod after preemption; the revert must ignore that and
+	// restore pod1 to node1, not to node2.
+	victim.Spec.NodeName = "node2"
+	if _, err := cs.Unpreempt(handle); err != nil {
+		t.Fatalf("Unpreempt: %v", err)
+	}
+	ft.VerifySnapshot(t, snap, map[string]sets.Set[string]{"node1": sets.New("pod1"), "node2": sets.New[string]()})
+}
+
+func TestTransactionFailedRollbackInvalidatesPriorHandles(t *testing.T) {
+	ctx := context.Background()
+	node1 := st.MakeNode().Name("node1").Capacity(map[v1.ResourceName]string{v1.ResourcePods: "10"}).Obj()
+	pod1 := st.MakePod().Name("pod1").Namespace("default").UID("uid-pod1").Node("node1").Obj()
+	cs, _, _ := setupSnapshotTest(t, ctx, []*v1.Node{node1}, []*v1.Pod{pod1})
+
+	// A handle created before the transaction.
+	handle, err := cs.PreemptPods(ctx, []*v1.Pod{pod1})
+	if err != nil {
+		t.Fatalf("PreemptPods: %v", err)
+	}
+
+	undoBoom := errors.New("undo-boom")
+	err = cs.Transaction(ctx, func() (TransactionResult, error) {
+		cs.undoLog.registerOperation(func() error { return undoBoom })
+		return Revert, nil
+	})
+	if !errors.Is(err, undoBoom) {
+		t.Fatalf("Transaction should surface the failed rollback, got %v", err)
+	}
+
+	// A failed rollback leaves the snapshot inconsistent; the handle from before the
+	// transaction must not revalidate against it.
+	if _, err := cs.Unpreempt(handle); err == nil || !strings.Contains(err.Error(), "invalid") {
+		t.Fatalf("stale handle after failed rollback: want invalid, got %v", err)
+	}
+}


### PR DESCRIPTION
#### What type of PR is this?

/kind bug

#### What this PR does / why we need it:

The snapshot undo log could not report a failed undo. `undoLog` stored its operations as `[]func()`, and the revert helpers logged their own errors and returned nothing, so a `Transaction` rollback or an `Unpreempt` returned success even when restoring the shared `*cache.Snapshot` had failed and left it half-restored. The caller had no way to learn its state was inconsistent.

Undo operations are now `func() error`. `restoreState` runs every remaining undo even when one fails, since one failure should not strand the rest, and joins their errors. `Transaction` surfaces a failed rollback and `Unpreempt` surfaces a failed revert.

A failed rollback also has to stop the caller from reusing state the error just reported inconsistent. Preemption handles are validated against a version counter, and the previous code reset that counter to its pre-transaction value before checking whether the rollback had actually succeeded, which made handles from before the transaction valid again. On the failure path the version is now advanced instead, so a failed rollback in `Transaction`, `schedulePods`, `PreemptPods`, or `Unpreempt` invalidates every outstanding handle.

Two smaller hardening changes come with it. A preemption revert now restores from the pod copy taken at removal time rather than the caller's pod, which the caller may mutate between `PreemptPods` and `Unpreempt`. And `restoreState` rejects a target it cannot reach instead of unwinding past its retained history into a slice panic, now that it has an error to return.

#### Which issue(s) this PR fixes:

Fixes #7

#### Special notes for your reviewer:

This touches `snapshot.go`'s `Transaction`, `PreemptPods`, and `Unpreempt`, which #5 also touches, so it will need a small rebase once #5 lands.

Two scope notes:

The scheduling revert is deliberately left returning `nil`. It wraps the extracted upstream unreserve-and-forget: the `Unreserve` hook has no error return, and the `ForgetPod` error it does produce is logged through `HandleErrorWithContext`, matching kube-scheduler's own handling. Surfacing it would mean diverging that extracted path, so this PR keeps the wrapper faithful and only makes the library's own undo log error-aware.

`MutatingSnapshot.RestoreState` is a separate exported path with no callers today; it keeps its own map-ordered undo and still drops errors. It is out of scope here and worth a focused issue of its own rather than folding into this one. The broader mutable-snapshot rework in kubernetes/kubernetes#140181 may later replace both.

A failed undo can still leave framework (plugin reserve) state inconsistent, which a snapshot rebuild does not repair. This PR makes the observable failures visible and invalidates the handles so a caller can reinitialize rather than proceed on corrupt state; the repair itself belongs with #140181.

#### Does this PR introduce a user-facing change?

```release-note
`ClusterSnapshot.Transaction` and `Unpreempt` now return an error when the underlying undo fails instead of reporting success with a possibly half-restored snapshot, and a failed rollback invalidates outstanding preemption handles.
```
