### PR TITLE
snapshot: reject mutations on a stale ClusterSnapshot

### DIFF
--- a/pkg/state/state.go
+++ b/pkg/state/state.go
@@ -28,6 +28,8 @@ type ClusterState struct {
 	Cache      cache.Cache
 	profiles   *upstreamsync.ProfileMap
 	sharedSnap *cache.Snapshot
+	// generation is bumped on every Snapshot so a stale ClusterSnapshot can detect it.
+	generation uint64
 }
 
 // New creates a new ClusterState with an internal Kubernetes scheduler cache, frameworks,
@@ -44,9 +46,10 @@ func New(c cache.Cache, profiles *upstreamsync.ProfileMap, snap *cache.Snapshot)
 // in-place. Calling Snapshot again invalidates any previously returned ClusterSnapshot — the caller
 // must not use a previous snapshot after requesting a new one.
 func (s *ClusterState) Snapshot(logger klog.Logger) (*snapshot.ClusterSnapshot, error) {
+	s.generation++
 	snap := s.sharedSnap
 	if err := s.Cache.UpdateSnapshot(logger, snap); err != nil {
 		return nil, fmt.Errorf("failed to update snapshot: %w", err)
 	}
-	return snapshot.New(snap, s.profiles), nil
+	return snapshot.New(snap, s.profiles, snapshot.WithGeneration(&s.generation)), nil
 }

--- a/pkg/state/state_stale_test.go
+++ b/pkg/state/state_stale_test.go
@@ -1,0 +1,75 @@
+// Copyright The Kubernetes Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package state
+
+import (
+	"strings"
+	"testing"
+
+	v1 "k8s.io/api/core/v1"
+	"k8s.io/klog/v2"
+	"k8s.io/kubernetes/pkg/scheduler/backend/cache"
+	st "k8s.io/kubernetes/pkg/scheduler/testing"
+	"sigs.k8s.io/scheduler-library/pkg/upstreamsync/snapshot"
+)
+
+func TestClusterState_StaleSnapshotRejectsMutation(t *testing.T) {
+	ctx := t.Context()
+	logger := klog.FromContext(ctx)
+
+	sharedSnap := cache.NewEmptySnapshot()
+	state := New(cache.New(ctx, nil, false), newDummyProfileMap(), sharedSnap)
+	state.Cache.AddNode(logger, st.MakeNode().Name("node1").Obj())
+	victim := st.MakePod().Name("victim").Namespace("default").UID("victim").Node("node1").Obj()
+	victim2 := st.MakePod().Name("victim2").Namespace("default").UID("victim2").Node("node1").Obj()
+	for _, p := range []*v1.Pod{victim, victim2} {
+		if err := state.Cache.AddPod(logger, p); err != nil {
+			t.Fatalf("AddPod() error = %v", err)
+		}
+	}
+
+	stale, err := state.Snapshot(logger)
+	if err != nil {
+		t.Fatalf("Snapshot() error = %v", err)
+	}
+	// Take a handle while stale is still current, for the Unpreempt case below.
+	handle, err := stale.PreemptPods(ctx, []*v1.Pod{victim})
+	if err != nil {
+		t.Fatalf("PreemptPods() setup error = %v", err)
+	}
+
+	// A newer snapshot supersedes stale.
+	current, err := state.Snapshot(logger)
+	if err != nil {
+		t.Fatalf("Snapshot() error = %v", err)
+	}
+
+	// Every mutation entry point on the stale snapshot is rejected.
+	if _, err := stale.PreemptPods(ctx, []*v1.Pod{victim2}); err == nil || !strings.Contains(err.Error(), "stale") {
+		t.Fatalf("stale PreemptPods should be rejected, got %v", err)
+	}
+	if _, err := stale.Unpreempt(handle); err == nil || !strings.Contains(err.Error(), "stale") {
+		t.Fatalf("stale Unpreempt should be rejected, got %v", err)
+	}
+	err = stale.Transaction(ctx, func() (snapshot.TransactionResult, error) { return snapshot.Commit, nil })
+	if err == nil || !strings.Contains(err.Error(), "stale") {
+		t.Fatalf("stale Transaction should be rejected, got %v", err)
+	}
+
+	// The current snapshot still mutates normally.
+	if _, err := current.PreemptPods(ctx, []*v1.Pod{victim2}); err != nil {
+		t.Fatalf("current PreemptPods should succeed, got %v", err)
+	}
+}

--- a/pkg/state/state_stale_test.go
+++ b/pkg/state/state_stale_test.go
@@ -56,6 +56,14 @@ func TestClusterState_StaleSnapshotRejectsMutation(t *testing.T) {
 		t.Fatalf("Snapshot() error = %v", err)
 	}
 
+	// The handle belongs to stale, so the snapshot that superseded it will not
+	// replay it either. Only checking the receiver would let this through: the
+	// revert closes over the shared state, and current starts its own preemption
+	// versions at zero, which is what the handle recorded.
+	if _, err := current.Unpreempt(handle); err == nil {
+		t.Error("Unpreempt() on the current snapshot with a handle from the stale one = nil, want error")
+	}
+
 	// Every mutation entry point on the stale snapshot is rejected.
 	if _, err := stale.PreemptPods(ctx, []*v1.Pod{victim2}); err == nil || !strings.Contains(err.Error(), "stale") {
 		t.Fatalf("stale PreemptPods should be rejected, got %v", err)

--- a/pkg/upstreamsync/snapshot/snapshot.go
+++ b/pkg/upstreamsync/snapshot/snapshot.go
@@ -401,6 +401,7 @@ func (s *ClusterSnapshot) PreemptPods(ctx context.Context, pods []*v1.Pod) (_ *U
 	}
 
 	return &Unpreemption{
+		owner:                  s,
 		pods:                   pods,
 		revertFn:               unpreemptFn,
 		validPreemptionVersion: s.stateVersionForPreemption,
@@ -416,6 +417,9 @@ func (s *ClusterSnapshot) Unpreempt(u *Unpreemption) ([]*v1.Pod, error) {
 	}
 	if u == nil {
 		return nil, fmt.Errorf("preemption handle is nil")
+	}
+	if u.owner != s {
+		return nil, fmt.Errorf("preemption handle is invalid: it belongs to a superseded snapshot")
 	}
 	if s.stateVersionForPreemption != u.validPreemptionVersion {
 		return nil, fmt.Errorf("preemption handle is invalid: snapshot has been permanently mutated since preemption")

--- a/pkg/upstreamsync/snapshot/snapshot.go
+++ b/pkg/upstreamsync/snapshot/snapshot.go
@@ -54,6 +54,10 @@ type ClusterSnapshot struct {
 	// handles unusable, i.e. whenever the state they would be restoring into is no longer the one
 	// they were taken from. Unpreempt compares it with the value recorded in the handle.
 	stateVersionForPreemption uint64
+	// generation is fixed at creation; currentGeneration tracks the ClusterState's
+	// latest. They differ once a newer snapshot supersedes this one.
+	generation        uint64
+	currentGeneration *uint64
 }
 
 // undoLog is a stack of the operations reverting the mutations applied to the snapshot, most
@@ -102,17 +106,44 @@ func (ul *undoLog) commit() {
 	ul.undoOperations = nil
 }
 
+// Option configures a ClusterSnapshot at construction.
+type Option func(*ClusterSnapshot)
+
+// WithGeneration ties the snapshot to a ClusterState generation counter so it
+// rejects mutations once a newer snapshot supersedes it.
+func WithGeneration(current *uint64) Option {
+	return func(cs *ClusterSnapshot) {
+		cs.currentGeneration = current
+		if current != nil {
+			cs.generation = *current
+		}
+	}
+}
+
 // New creates a new ClusterSnapshot stub wrapping the provided scheduler snapshot and frameworks.
 //
 // Consumers should obtain a ClusterSnapshot from simulator.SchedulingSimulator instead, either via
 // NewClusterSnapshot or via NewClusterState followed by state.ClusterState.Snapshot: those build
 // the full plugin chain out of the KubeSchedulerConfiguration and initialize the scheduler metrics,
 // which this constructor expects to have been done already.
-func New(s *cache.Snapshot, profiles *upstreamsync.ProfileMap) *ClusterSnapshot {
-	return &ClusterSnapshot{
+func New(s *cache.Snapshot, profiles *upstreamsync.ProfileMap, opts ...Option) *ClusterSnapshot {
+	cs := &ClusterSnapshot{
 		profiles:          profiles,
 		schedulerSnapshot: s,
 	}
+	for _, opt := range opts {
+		opt(cs)
+	}
+	return cs
+}
+
+// checkNotStale errors if a newer snapshot from the same ClusterState exists.
+// Mutating a superseded one corrupts the cache.Snapshot they all share.
+func (s *ClusterSnapshot) checkNotStale() error {
+	if s.currentGeneration != nil && *s.currentGeneration != s.generation {
+		return fmt.Errorf("stale snapshot: a newer snapshot has been created from the cluster state; a previous snapshot must not be used after requesting a new one")
+	}
+	return nil
 }
 
 // Transaction executes the provided function within a transaction.
@@ -120,6 +151,9 @@ func New(s *cache.Snapshot, profiles *upstreamsync.ProfileMap) *ClusterSnapshot 
 // Only a single active transaction is supported at any given time;
 // attempting to start a nested transaction will return an error.
 func (s *ClusterSnapshot) Transaction(ctx context.Context, transactionFn func() (TransactionResult, error)) error {
+	if err := s.checkNotStale(); err != nil {
+		return err
+	}
 	if s.transactionInProgress {
 		return fmt.Errorf("a transaction is already in progress")
 	}
@@ -232,6 +266,9 @@ func (s *ClusterSnapshot) SchedulePodsByTemplate(ctx context.Context, template *
 }
 
 func (s *ClusterSnapshot) schedulePods(ctx context.Context, pods iter.Seq[*v1.Pod], placement *fwk.Placement, opts SchedulePodsOptions) (_ []SchedulingResult, err error) {
+	if err := s.checkNotStale(); err != nil {
+		return nil, err
+	}
 	if placement == nil || len(placement.Nodes) == 0 {
 		return nil, nil
 	}
@@ -309,6 +346,9 @@ func (s *ClusterSnapshot) MakePlacement(candidateNodeNames []string) (*fwk.Place
 // If any pod fails to be preempted, all previously preempted pods in this call
 // are automatically restored and an error is returned.
 func (s *ClusterSnapshot) PreemptPods(ctx context.Context, pods []*v1.Pod) (_ *Unpreemption, err error) {
+	if err := s.checkNotStale(); err != nil {
+		return nil, err
+	}
 	// Validate all pods before making any changes.
 	for _, pod := range pods {
 		if pod.Spec.NodeName == "" {
@@ -371,6 +411,9 @@ func (s *ClusterSnapshot) PreemptPods(ctx context.Context, pods []*v1.Pod) (_ *U
 // The handle is consumed even if putting some of the pods back fails, in which case the pods that
 // were restored are still registered in the undo log and are rolled back with the transaction.
 func (s *ClusterSnapshot) Unpreempt(u *Unpreemption) ([]*v1.Pod, error) {
+	if err := s.checkNotStale(); err != nil {
+		return nil, err
+	}
 	if u == nil {
 		return nil, fmt.Errorf("preemption handle is nil")
 	}

--- a/pkg/upstreamsync/snapshot/types.go
+++ b/pkg/upstreamsync/snapshot/types.go
@@ -86,6 +86,10 @@ type SchedulingResult struct {
 // snapshot it was taken from: any permanent mutation of that snapshot invalidates it, since the
 // pods it holds could no longer be restored to the state they were removed from.
 type Unpreemption struct {
+	// owner is the snapshot that took the pods away. The version below says
+	// whether it has moved on since; this says whether it is the one being
+	// asked, because a newer wrapper starts its versions again from zero.
+	owner *ClusterSnapshot
 	// pods are the pods that were preempted, returned to the caller by Unpreempt.
 	pods []*v1.Pod
 	// revertFn puts the pods back into the snapshot, registering the undo of each addition.


### PR DESCRIPTION
#### What type of PR is this?

/kind bug

#### What this PR does / why we need it:

Every `ClusterSnapshot` handed out by a `ClusterState` shares one underlying `*cache.Snapshot`, and the type documents that a caller must not use a previous snapshot after requesting a new one. Nothing enforced that. A caller holding an older wrapper could still call `PreemptPods`, `Unpreempt`, or a scheduling method on it after a newer `Snapshot()` had been taken, mutating the shared snapshot behind the current one's back — a duplicate pod, double-counted resources, and a refresh that may then skip the node because its cache-side generation did not change. Nothing failed loudly.

`ClusterState` now bumps a generation counter on every `Snapshot`, and each `ClusterSnapshot` captures it through a `WithGeneration` option and holds a pointer to the live counter. A mutation on a snapshot whose captured generation no longer matches the cluster state's is rejected with an error rather than allowed to corrupt the shared snapshot. Snapshots built without the option, such as the standalone simulator, keep the previous unguarded behavior.

#### Which issue(s) this PR fixes:

Fixes #9

#### Special notes for your reviewer:

`snapshot.New` now takes functional options (the same shape as `frameworkruntime.NewFramework`); `WithGeneration(*uint64)` ties a snapshot to the `ClusterState` counter, so existing `New(snap, profiles)` callers are untouched. The guard sits at the entry of `PreemptPods`, `Unpreempt`, the internal `schedulePods`, and `Transaction`. The counter is a plain `uint64` read without synchronization, which matches the rest of this package — `ClusterState`/`ClusterSnapshot` are single-goroutine by contract. This touches `state.go` and `snapshot.go`, which #5 also touches, so it will need a small rebase once #5 lands. The test pins that a superseded snapshot's `PreemptPods`, `Unpreempt`, and `Transaction` are all rejected while the current one still works.

#### Does this PR introduce a user-facing change?

```release-note
`ClusterSnapshot` mutations (`PreemptPods`, `Unpreempt`, scheduling) now return an error when called on a snapshot that a newer `ClusterState.Snapshot` has superseded, instead of silently corrupting the shared snapshot.
```
