### PR TITLE
Sync OWNERS with active SIG Scheduling OWNERS

### DIFF
--- a/OWNERS
+++ b/OWNERS
@@ -1,9 +1,14 @@
 # See the OWNERS docs at https://go.k8s.io/owners
 
 approvers:
+  - ania-borowiec
   - dom4ha
   - macsko
   - sanposhiho
-
+reviewers:
+  - Argh4k
+  - brejman
+  - mm4tt
+  - tosi3k
 labels:
   - sig/scheduling


### PR DESCRIPTION
This PR syncs the OWNERS file of scheduler-library with active SIG Scheduling reviewers/approvers. It contains `Argh4k` and `brejman` that are approved as SIG reviewers, but are waiting for their PRs to be merged into k/k.