### PR TITLE
snapshot: refuse a placement that names a node twice

### DIFF
--- a/pkg/simulator/simulator.go
+++ b/pkg/simulator/simulator.go
@@ -24,6 +24,7 @@ import (
 	"sigs.k8s.io/scheduler-library/pkg/upstreamsync/snapshot"
 
 	v1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/util/sets"
 	utilfeature "k8s.io/apiserver/pkg/util/feature"
 	"k8s.io/client-go/informers"
 	"k8s.io/client-go/kubernetes"
@@ -41,7 +42,7 @@ import (
 // simulation visible from this package; consumers are not expected to implement it.
 type Simulator interface {
 	// MakePlacement turns node names into the *fwk.Placement that the other methods restrict the simulation to.
-	MakePlacement(candidateNodeNames []string) (*fwk.Placement, error)
+	MakePlacement(candidateNodeNames sets.Set[string]) (*fwk.Placement, error)
 
 	// CanSchedulePod reports which of the nodes in the placement fit a single pod, leaving the
 	// snapshot untouched. The returned *schedFwk.Diagnosis explains why the remaining nodes were

--- a/pkg/simulator/simulator_test.go
+++ b/pkg/simulator/simulator_test.go
@@ -22,6 +22,7 @@ import (
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/apimachinery/pkg/util/sets"
 	"k8s.io/client-go/informers"
 	"k8s.io/client-go/kubernetes/fake"
 	"k8s.io/klog/v2"
@@ -356,7 +357,7 @@ func TestNewClusterSnapshot_Scheduling(t *testing.T) {
 		},
 	}
 
-	placement, err := snap.MakePlacement([]string{"node1"})
+	placement, err := snap.MakePlacement(sets.New("node1"))
 	if err != nil {
 		t.Fatalf("MakePlacement failed: %v", err)
 	}
@@ -427,7 +428,7 @@ func TestClusterState_Scheduling(t *testing.T) {
 		},
 	}
 
-	placement, err := snap.MakePlacement([]string{"node1"})
+	placement, err := snap.MakePlacement(sets.New("node1"))
 	if err != nil {
 		t.Fatalf("MakePlacement failed: %v", err)
 	}

--- a/pkg/state/state_test.go
+++ b/pkg/state/state_test.go
@@ -510,7 +510,7 @@ func TestClusterState_SyncSnapshot_RevertsMutations(t *testing.T) {
 
 	csnap := state.GetAssociatedSnapshot()
 
-	placement, err := csnap.MakePlacement([]string{"node1"})
+	placement, err := csnap.MakePlacement(sets.New("node1"))
 	if err != nil {
 		t.Fatalf("MakePlacement failed: %v", err)
 	}

--- a/pkg/upstreamsync/snapshot/helpers_test.go
+++ b/pkg/upstreamsync/snapshot/helpers_test.go
@@ -23,6 +23,7 @@ import (
 
 	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/sets"
 	"k8s.io/kube-scheduler/framework"
 	"k8s.io/kubernetes/pkg/scheduler/backend/cache"
 	st "k8s.io/kubernetes/pkg/scheduler/testing"
@@ -348,7 +349,7 @@ func TestScheduleOnePod(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			cs, snap, _ := setupSnapshotTest(t, ctx, tc.nodes, nil)
 
-			placement, err := cs.MakePlacement([]string{tc.candidate})
+			placement, err := cs.MakePlacement(sets.New(tc.candidate))
 			if err != nil {
 				t.Fatalf("MakePlacement failed: %v", err)
 			}

--- a/pkg/upstreamsync/snapshot/snapshot.go
+++ b/pkg/upstreamsync/snapshot/snapshot.go
@@ -298,7 +298,15 @@ func (s *ClusterSnapshot) schedulePods(ctx context.Context, pods iter.Seq[*v1.Po
 // MakePlacement creates a framework.Placement containing NodeInfo structures for each candidate node name.
 func (s *ClusterSnapshot) MakePlacement(candidateNodeNames []string) (*fwk.Placement, error) {
 	nodes := make([]fwk.NodeInfo, 0, len(candidateNodeNames))
+	// A name given twice makes the placement as long as a wider set of nodes,
+	// and AssumePlacement reads a placement the length of the snapshot as every
+	// node before it looks at any of them.
+	named := make(map[string]struct{}, len(candidateNodeNames))
 	for _, name := range candidateNodeNames {
+		if _, repeated := named[name]; repeated {
+			return nil, fmt.Errorf("node %s is named more than once in the placement", name)
+		}
+		named[name] = struct{}{}
 		ni, err := s.schedulerSnapshot.NodeInfos().Get(name)
 		if err != nil {
 			return nil, fmt.Errorf("error getting %s from snapshot: %w", name, err)

--- a/pkg/upstreamsync/snapshot/snapshot.go
+++ b/pkg/upstreamsync/snapshot/snapshot.go
@@ -23,6 +23,7 @@ import (
 	"slices"
 
 	v1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/util/sets"
 	"k8s.io/klog/v2"
 	"sigs.k8s.io/scheduler-library/pkg/upstreamsync"
 
@@ -179,7 +180,7 @@ func (s *ClusterSnapshot) CanSchedulePod(ctx context.Context, pod *v1.Pod, place
 	feasibleNodes := make([]string, 0)
 	var diagnosis framework.Diagnosis
 	sched := upstreamsync.NewScheduler(s.schedulerSnapshot, 0, 0, math.MaxInt32)
-	err = s.schedulerSnapshot.AssumePlacement(placement)
+	err = s.assumePlacement(placement)
 	if err != nil {
 		return nil, nil, fmt.Errorf("failed to assume placement: %w", err)
 	}
@@ -258,7 +259,7 @@ func (s *ClusterSnapshot) schedulePods(ctx context.Context, pods iter.Seq[*v1.Po
 
 	currentCycle := int64(0)
 
-	err = s.schedulerSnapshot.AssumePlacement(placement)
+	err = s.assumePlacement(placement)
 	if err != nil {
 		return nil, fmt.Errorf("error assuming placement: %w", err)
 	}
@@ -295,18 +296,27 @@ func (s *ClusterSnapshot) schedulePods(ctx context.Context, pods iter.Seq[*v1.Po
 	return result, nil
 }
 
-// MakePlacement creates a framework.Placement containing NodeInfo structures for each candidate node name.
-func (s *ClusterSnapshot) MakePlacement(candidateNodeNames []string) (*fwk.Placement, error) {
-	nodes := make([]fwk.NodeInfo, 0, len(candidateNodeNames))
-	// A name given twice makes the placement as long as a wider set of nodes,
-	// and AssumePlacement reads a placement the length of the snapshot as every
-	// node before it looks at any of them.
-	named := make(map[string]struct{}, len(candidateNodeNames))
-	for _, name := range candidateNodeNames {
-		if _, repeated := named[name]; repeated {
-			return nil, fmt.Errorf("node %s is named more than once in the placement", name)
+// assumePlacement is the one way this package hands a placement to the
+// scheduler. A node listed twice makes the placement longer than the set of
+// nodes it names, which AssumePlacement reads as every node in the snapshot
+// before it looks at any of them, and which leaves the same node in the
+// candidate list twice when it does not.
+func (s *ClusterSnapshot) assumePlacement(placement *fwk.Placement) error {
+	named := sets.New[string]()
+	for _, node := range placement.Nodes {
+		name := node.Node().Name
+		if named.Has(name) {
+			return fmt.Errorf("node %s is named more than once in the placement", name)
 		}
-		named[name] = struct{}{}
+		named.Insert(name)
+	}
+	return s.schedulerSnapshot.AssumePlacement(placement)
+}
+
+// MakePlacement creates a framework.Placement containing NodeInfo structures for each candidate node name.
+func (s *ClusterSnapshot) MakePlacement(candidateNodeNames sets.Set[string]) (*fwk.Placement, error) {
+	nodes := make([]fwk.NodeInfo, 0, len(candidateNodeNames))
+	for name := range candidateNodeNames {
 		ni, err := s.schedulerSnapshot.NodeInfos().Get(name)
 		if err != nil {
 			return nil, fmt.Errorf("error getting %s from snapshot: %w", name, err)

--- a/pkg/upstreamsync/snapshot/snapshot_test.go
+++ b/pkg/upstreamsync/snapshot/snapshot_test.go
@@ -529,6 +529,13 @@ func TestMakePlacement(t *testing.T) {
 	if err == nil {
 		t.Fatalf("expected error when node not found in snapshot, got nil")
 	}
+
+	// Two entries for one node make the placement as long as this two-node
+	// snapshot, which AssumePlacement reads as no restriction at all.
+	_, err = cs.MakePlacement([]string{"node1", "node1"})
+	if err == nil {
+		t.Fatalf("expected error when a node is named twice, got nil")
+	}
 }
 
 func TestCanSchedulePod(t *testing.T) {

--- a/pkg/upstreamsync/snapshot/snapshot_test.go
+++ b/pkg/upstreamsync/snapshot/snapshot_test.go
@@ -114,7 +114,7 @@ func schedule(podNames []string, candidateNodes []string, opts SchedulePodsOptio
 			}
 			pods = append(pods, p)
 		}
-		placement, err := sc.cs.MakePlacement(candidateNodes)
+		placement, err := sc.cs.MakePlacement(sets.New(candidateNodes...))
 		if err != nil {
 			t.Fatalf("schedule: MakePlacement failed: %v", err)
 		}
@@ -132,7 +132,7 @@ func canSchedule(podName string, candidateNodes []string) stepFn {
 		if !ok {
 			t.Fatalf("canSchedule: pod %q not found in stepContext", podName)
 		}
-		placement, err := sc.cs.MakePlacement(candidateNodes)
+		placement, err := sc.cs.MakePlacement(sets.New(candidateNodes...))
 		if err != nil {
 			t.Fatalf("canSchedule: MakePlacement failed: %v", err)
 		}
@@ -517,7 +517,7 @@ func TestMakePlacement(t *testing.T) {
 
 	cs, _, _ := setupSnapshotTest(t, context.Background(), []*v1.Node{node1, node2}, nil)
 
-	placement, err := cs.MakePlacement([]string{"node1", "node2"})
+	placement, err := cs.MakePlacement(sets.New("node1", "node2"))
 	if err != nil {
 		t.Fatalf("unexpected error from MakePlacement: %v", err)
 	}
@@ -525,16 +525,36 @@ func TestMakePlacement(t *testing.T) {
 		t.Fatalf("expected placement with 2 nodes, got %v", placement)
 	}
 
-	_, err = cs.MakePlacement([]string{"node1", "non-existent-node"})
+	_, err = cs.MakePlacement(sets.New("node1", "non-existent-node"))
 	if err == nil {
 		t.Fatalf("expected error when node not found in snapshot, got nil")
 	}
+}
 
-	// Two entries for one node make the placement as long as this two-node
-	// snapshot, which AssumePlacement reads as no restriction at all.
-	_, err = cs.MakePlacement([]string{"node1", "node1"})
+// Placement.Nodes is an exported slice on an upstream type, so a placement that
+// left MakePlacement well formed does not have to arrive that way.
+func TestCanSchedulePodRejectsPlacementNamingANodeTwice(t *testing.T) {
+	ctx := t.Context()
+	node := func(name string) *v1.Node {
+		return st.MakeNode().Name(name).Capacity(map[v1.ResourceName]string{
+			v1.ResourceCPU:    "0",
+			v1.ResourceMemory: "0",
+			v1.ResourcePods:   "110",
+		}).Obj()
+	}
+	cs, _, _ := setupSnapshotTest(t, ctx, []*v1.Node{node("node1"), node("node2")}, nil)
+	pod := st.MakePod().Name("pod1").Namespace("default").UID("uid-pod1").
+		SchedulerName(v1.DefaultSchedulerName).Obj()
+
+	placement, err := cs.MakePlacement(sets.New("node1", "node2"))
+	if err != nil {
+		t.Fatalf("MakePlacement() error = %v", err)
+	}
+	placement.Nodes[1] = placement.Nodes[0]
+
+	nodes, _, err := cs.CanSchedulePod(ctx, pod, placement)
 	if err == nil {
-		t.Fatalf("expected error when a node is named twice, got nil")
+		t.Fatalf("expected an error for a placement naming node1 twice, got nodes %v", nodes)
 	}
 }
 
@@ -601,7 +621,7 @@ func TestCanSchedulePod(t *testing.T) {
 			}
 			pod := podBuilder.Obj()
 
-			placement, err := cs.MakePlacement(tc.candidateNodes)
+			placement, err := cs.MakePlacement(sets.New(tc.candidateNodes...))
 			if err != nil && !tc.expectErr {
 				t.Fatalf("MakePlacement() error = %v", err)
 			}
@@ -860,7 +880,7 @@ func TestSchedulePods(t *testing.T) {
 
 			cs, snap, _ := setupSnapshotTest(t, ctx, tc.nodes, nil)
 
-			placement, err := cs.MakePlacement(tc.candidateNodes)
+			placement, err := cs.MakePlacement(sets.New(tc.candidateNodes...))
 			if err != nil && !tc.expectErr {
 				t.Fatalf("MakePlacement() error = %v, expectErr %v", err, tc.expectErr)
 			}
@@ -1042,7 +1062,7 @@ func TestSchedulePodsByTemplate(t *testing.T) {
 
 			cs, snap, _ := setupSnapshotTest(t, ctx, tc.nodes, nil)
 
-			placement, err := cs.MakePlacement(tc.candidateNodes)
+			placement, err := cs.MakePlacement(sets.New(tc.candidateNodes...))
 			if err != nil && !tc.expectErr {
 				t.Fatalf("MakePlacement() error = %v, expectErr %v", err, tc.expectErr)
 			}
@@ -1107,7 +1127,7 @@ func TestResetMutations_NodeGenerationRestored(t *testing.T) {
 		t.Fatalf("PreemptPods failed: %v", err)
 	}
 
-	placement, err := cs.MakePlacement([]string{"node2"})
+	placement, err := cs.MakePlacement(sets.New("node2"))
 	if err != nil {
 		t.Fatalf("MakePlacement failed: %v", err)
 	}

--- a/test/integration/scheduler/simulator_integration_test.go
+++ b/test/integration/scheduler/simulator_integration_test.go
@@ -19,6 +19,7 @@ import (
 
 	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/sets"
 	"k8s.io/client-go/informers"
 	"k8s.io/klog/v2"
 	schedulerapi "k8s.io/kubernetes/pkg/scheduler/apis/config"
@@ -115,7 +116,7 @@ func TestSimulatorIntegrationFlow(t *testing.T) {
 		v1.ResourceCPU: "4",
 	}).Obj()
 
-	placement, err := snap.MakePlacement([]string{"node1"})
+	placement, err := snap.MakePlacement(sets.New("node1"))
 	if err != nil {
 		t.Fatalf("MakePlacement failed: %v", err)
 	}


### PR DESCRIPTION
A placement whose `Nodes` slice names the same node twice is longer than the set of distinct nodes it names. `AssumePlacement` reads that length before it looks at the nodes, so a repeat makes it misjudge the snapshot.

## Problem Statement

`AssumePlacement` upstream compares the placement's length against the snapshot before it looks at any of the nodes in it:

```go
func (s *Snapshot) AssumePlacement(placement *fwk.Placement) error {
	if len(placement.Nodes) == len(s.nodeInfoList) {
		// All nodes in placement, meaning we can treat it the same as no placement and avoid copying the buffer.
		s.ForgetPlacement()
		return nil
	}
```

(`k8s.io/kubernetes@v1.36.0`, the version this module builds against, `pkg/scheduler/backend/cache/snapshot.go:426`)

The name and pointer checks below it are only reached on the other branch. So on a two node snapshot, a placement naming `node-a` twice is read as no restriction at all, and `node-b` becomes a candidate for a caller that never named it:

```go
placement, _ := cs.MakePlacement(sets.New("node-a", "node-b"))
placement.Nodes[1] = placement.Nodes[0] // now names only node-a

nodes, _, _ := cs.CanSchedulePod(ctx, pod, placement)
// nodes contains node-b
```

The other branch is not safe either. `placement.Nodes` is stored as the placement's node list unchanged, and `NumNodes` returns its length, so a repeated node inflates the node count and appears twice in the candidate list.

`Placement.Nodes` is an exported slice on an upstream type, and all three scheduling entry points accept a `*fwk.Placement` from the caller, so a placement can reach the scheduler with a repeat even when `MakePlacement` did not build one.

I found this while re-reading #11 and it is separate from the staleness question there, so it is its own change.

## Proposed Changes

Two parts.

`MakePlacement` takes a `sets.Set[string]`, so it cannot name a node twice in the first place.

`assumePlacement` checks the placement where this package hands it to the scheduler. `CanSchedulePod` and `schedulePods` both go through it, so it is the only path from here into `AssumePlacement`, and it catches a repeat that was built or edited by hand:

```go
func (s *ClusterSnapshot) assumePlacement(placement *fwk.Placement) error {
	named := sets.New[string]()
	for _, node := range placement.Nodes {
		name := node.Node().Name
		if named.Has(name) {
			return fmt.Errorf("node %s is named more than once in the placement", name)
		}
		named.Insert(name)
	}
	...
```

The set input collapses a repeat silently, which reads fine for a candidate list. The boundary check then surfaces a malformed placement that did not come from `MakePlacement`, instead of letting its length overstate the number of distinct nodes.

The cost is one pass over the placement per assume, including the whole-cluster case the upstream fast path exists to keep cheap.

## Testing

`TestCanSchedulePodRejectsPlacementNamingANodeTwice` builds a well formed placement, widens it by hand, and expects the error. Reverting `snapshot.go` alone turns it red:

```
--- FAIL: TestCanSchedulePodRejectsPlacementNamingANodeTwice
    snapshot_test.go: expected an error for a placement naming node1 twice, got nodes [node1 node2]
```

That message is the behaviour this is about: a placement naming only `node1` returned `node2`. The test fails on the widening, not on the factory, so it pins the boundary that actually matters.

`go build ./...`, `go vet ./...`, and `go test -race ./pkg/...` pass on the branch. The `test/integration/scheduler` suite runs in CI.

## What this does not change

A `*fwk.Placement` still carries no owner, so one made by a different snapshot is not detected. That is related to the lifecycle concerns discussed in #11 but is neither addressed here nor by that change, and it wants the abstraction there to settle first.

Upstream still validates after the length comparison, so this is a guard on our side of the boundary, not a fix to it.

## AI usage

This PR was written in part with the assistance of generative AI. I have reviewed and tested every change myself.
