### PR TITLE
add exclusions

### DIFF
--- a/pkg/framework/testing/framework_prep.go
+++ b/pkg/framework/testing/framework_prep.go
@@ -51,11 +51,13 @@ func SetupSnapshotTest(ctx context.Context, pods []*v1.Pod, nodes []*v1.Node) (*
 					PreFilter: schedulerapi.PluginSet{
 						Enabled: []schedulerapi.Plugin{
 							{Name: "NodeResourcesFit"},
+							{Name: "NodeAffinity"},
 						},
 					},
 					Filter: schedulerapi.PluginSet{
 						Enabled: []schedulerapi.Plugin{
 							{Name: "NodeResourcesFit"},
+							{Name: "NodeAffinity"},
 						},
 					},
 					Bind: schedulerapi.PluginSet{
@@ -72,6 +74,10 @@ func SetupSnapshotTest(ctx context.Context, pods []*v1.Pod, nodes []*v1.Node) (*
 								Type: schedulerapi.LeastAllocated,
 							},
 						},
+					},
+					{
+						Name: "NodeAffinity",
+						Args: &schedulerapi.NodeAffinityArgs{},
 					},
 				},
 			},

--- a/pkg/upstreamsync/scheduler.go
+++ b/pkg/upstreamsync/scheduler.go
@@ -293,7 +293,7 @@ func (sched *Scheduler) schedulePod(ctx context.Context, fwk framework.Framework
 		return result, scheduler.ErrNoNodesAvailable
 	}
 
-	feasibleNodes, diagnosis, nodeHint, err := sched.findNodesThatFitPod(ctx, fwk, podInfo, false)
+	feasibleNodes, diagnosis, _, nodeHint, err := sched.findNodesThatFitPod(ctx, fwk, podInfo, false)
 	if err != nil {
 		return result, err
 	}
@@ -341,12 +341,14 @@ func (sched *Scheduler) schedulePod(ctx context.Context, fwk framework.Framework
 }
 
 // FindAllNodesThatFitPod returns every node in the placement that fits the pod, together with the
-// diagnosis explaining why the remaining ones were rejected.
+// diagnosis explaining why the remaining ones were rejected, and the set of plugins that narrowed
+// the candidate nodes via PreFilterResult, captured before Filter rejections are added to
+// Diagnosis.UnschedulablePlugins.
 //
 // UPSTREAM-DIFF: library-only. Upstream never needs the complete set of feasible nodes, as it
 // stops as soon as it has enough candidates to score. Feasibility checks (see
 // ClusterSnapshot.CanSchedulePod) do need it.
-func (sched *Scheduler) FindAllNodesThatFitPod(ctx context.Context, schedFramework framework.Framework, podInfo *PendingPod) ([]fwk.NodeInfo, framework.Diagnosis, string, error) {
+func (sched *Scheduler) FindAllNodesThatFitPod(ctx context.Context, schedFramework framework.Framework, podInfo *PendingPod) ([]fwk.NodeInfo, framework.Diagnosis, sets.Set[string], string, error) {
 	return sched.findNodesThatFitPod(ctx, schedFramework, podInfo, true)
 }
 
@@ -356,8 +358,10 @@ func (sched *Scheduler) FindAllNodesThatFitPod(ctx context.Context, schedFramewo
 // UPSTREAM-DIFF: takes the additional findAll flag (see FindAllNodesThatFitPod). When it is set,
 // the nominated node shortcut is skipped, because returning early with the nominated node alone
 // would hide the other feasible nodes the caller asked for. The CycleState comes from podInfo and
-// the extenders come from the framework instead of sched.Extenders.
-func (sched *Scheduler) findNodesThatFitPod(ctx context.Context, schedFramework framework.Framework, podInfo *PendingPod, findAll bool) ([]fwk.NodeInfo, framework.Diagnosis, string, error) {
+// the extenders come from the framework instead of sched.Extenders. Also returns the narrowing
+// plugin set captured after PreFilter ran, before Filter rejections are added to
+// Diagnosis.UnschedulablePlugins.
+func (sched *Scheduler) findNodesThatFitPod(ctx context.Context, schedFramework framework.Framework, podInfo *PendingPod, findAll bool) ([]fwk.NodeInfo, framework.Diagnosis, sets.Set[string], string, error) {
 	state := podInfo.CycleState
 	logger := klog.FromContext(ctx)
 	diagnosis := framework.Diagnosis{
@@ -365,15 +369,19 @@ func (sched *Scheduler) findNodesThatFitPod(ctx context.Context, schedFramework 
 	}
 	allNodes, err := sched.nodeInfoSnapshot.ListNodesInPlacement()
 	if err != nil {
-		return nil, diagnosis, "", err
+		return nil, diagnosis, nil, "", err
 	}
 	// Run "prefilter" plugins.
 	pod := podInfo.Pod
 	preRes, s, unscheduledPlugins := schedFramework.RunPreFilterPlugins(ctx, state, pod)
 	diagnosis.UnschedulablePlugins = unscheduledPlugins
+	// Capture the narrowing plugins while the set is still precise:
+	// findNodesThatPassFilters below adds every Filter-rejecting plugin to
+	// diagnosis.UnschedulablePlugins via AddPluginStatus.
+	narrowingPlugins := unscheduledPlugins.Clone()
 	if !s.IsSuccess() {
 		if !s.IsRejected() {
-			return nil, diagnosis, "", s.AsError()
+			return nil, diagnosis, narrowingPlugins, "", s.AsError()
 		}
 		// All nodes in NodeToStatus will have the same status so that they can be handled in the preemption.
 		diagnosis.NodeToStatus.SetAbsentNodesStatus(s)
@@ -383,7 +391,7 @@ func (sched *Scheduler) findNodesThatFitPod(ctx context.Context, schedFramework 
 		diagnosis.PreFilterMsg = msg
 		logger.V(5).Info("Status after running PreFilter plugins for pod", "pod", klog.KObj(pod), "status", msg)
 		diagnosis.AddPluginStatus(s)
-		return nil, diagnosis, "", nil
+		return nil, diagnosis, narrowingPlugins, "", nil
 	}
 
 	var nodeHint string
@@ -404,7 +412,7 @@ func (sched *Scheduler) findNodesThatFitPod(ctx context.Context, schedFramework 
 		}
 		// Nominated node passes all the filters, scheduler is good to assign this node to the pod.
 		if len(feasibleNodes) != 0 {
-			return feasibleNodes, diagnosis, nodeHint, nil
+			return feasibleNodes, diagnosis, narrowingPlugins, nodeHint, nil
 		}
 	}
 
@@ -426,12 +434,12 @@ func (sched *Scheduler) findNodesThatFitPod(ctx context.Context, schedFramework 
 	processedNodes := len(feasibleNodes) + diagnosis.NodeToStatus.Len()
 	sched.nextStartNodeIndex = (sched.nextStartNodeIndex + processedNodes) % len(allNodes)
 	if err != nil {
-		return nil, diagnosis, nodeHint, err
+		return nil, diagnosis, narrowingPlugins, nodeHint, err
 	}
 
 	feasibleNodesAfterExtender, err := findNodesThatPassExtenders(ctx, schedFramework.Extenders(), pod, feasibleNodes, diagnosis.NodeToStatus)
 	if err != nil {
-		return nil, diagnosis, nodeHint, err
+		return nil, diagnosis, narrowingPlugins, nodeHint, err
 	}
 	if len(feasibleNodesAfterExtender) != len(feasibleNodes) {
 		// Extenders filtered out some nodes.
@@ -448,7 +456,7 @@ func (sched *Scheduler) findNodesThatFitPod(ctx context.Context, schedFramework 
 		diagnosis.UnschedulablePlugins.Insert(framework.ExtenderName)
 	}
 
-	return feasibleNodesAfterExtender, diagnosis, nodeHint, nil
+	return feasibleNodesAfterExtender, diagnosis, narrowingPlugins, nodeHint, nil
 }
 
 // evaluateNominatedNode checks whether the pod fits the node it was nominated to (or hinted at).

--- a/pkg/upstreamsync/snapshot/exclusions.go
+++ b/pkg/upstreamsync/snapshot/exclusions.go
@@ -61,16 +61,23 @@ type NodeExclusion struct {
 // Diagnosis via NodeExclusionsFromDiagnosis. The feasible-node result is
 // identical to CanSchedulePod's; on error no exclusions are derived.
 func (s *ClusterSnapshot) CanSchedulePodWithExclusions(ctx context.Context, pod *v1.Pod, placement *fwk.Placement) ([]string, []NodeExclusion, *framework.Diagnosis, error) {
-	feasibleNodes, diagnosis, err := s.CanSchedulePod(ctx, pod, placement)
+	feasibleNodes, narrowingPlugins, diagnosis, err := s.canSchedulePod(ctx, pod, placement)
 	if err != nil {
 		return feasibleNodes, nil, diagnosis, err
 	}
-	return feasibleNodes, NodeExclusionsFromDiagnosis(placement, feasibleNodes, diagnosis), diagnosis, nil
+	return feasibleNodes, NodeExclusionsFromDiagnosis(placement, feasibleNodes, diagnosis, narrowingPlugins), diagnosis, nil
 }
 
 // NodeExclusionsFromDiagnosis derives one NodeExclusion per placement node
 // that is not in feasibleNodeNames, in placement order. It reads only typed
-// Diagnosis data and does not mutate the Diagnosis.
+// data and does not mutate the Diagnosis.
+//
+// narrowingPlugins is the set of plugins that narrowed the candidate nodes
+// via PreFilterResult, captured after PreFilter and before Filter ran (see
+// CanSchedulePodWithExclusions). It cannot be recovered from the Diagnosis
+// afterwards: Diagnosis.UnschedulablePlugins also accumulates every
+// Filter-rejecting plugin as evaluation proceeds. A nil set leaves narrowed
+// nodes at RejectionStageUnknown.
 //
 // Attribution follows how the framework populates the Diagnosis:
 //   - Filter plugins store an explicit per-node status tagged with the
@@ -78,12 +85,12 @@ func (s *ClusterSnapshot) CanSchedulePodWithExclusions(ctx context.Context, pod 
 //   - A PreFilter plugin rejection is stored as the absent-nodes status, also
 //     tagged with the plugin name, covering every node without an explicit
 //     status.
-//   - PreFilterResult narrowing stores a plugin-less absent-nodes status and
-//     records the narrowing plugins in UnschedulablePlugins; a plugin is
-//     attributed only when exactly one is recorded.
+//   - PreFilterResult narrowing stores a plugin-less absent-nodes status; the
+//     narrowing plugin is attributed from narrowingPlugins only when exactly
+//     one is recorded, never guessed among several.
 //   - Extenders store explicit plugin-less per-node statuses and add
 //     framework.ExtenderName to UnschedulablePlugins.
-func NodeExclusionsFromDiagnosis(placement *fwk.Placement, feasibleNodeNames []string, diag *framework.Diagnosis) []NodeExclusion {
+func NodeExclusionsFromDiagnosis(placement *fwk.Placement, feasibleNodeNames []string, diag *framework.Diagnosis, narrowingPlugins sets.Set[string]) []NodeExclusion {
 	if placement == nil || len(placement.Nodes) == 0 {
 		return nil
 	}
@@ -100,12 +107,12 @@ func NodeExclusionsFromDiagnosis(placement *fwk.Placement, feasibleNodeNames []s
 		if node == nil || feasible.Has(node.Name) {
 			continue
 		}
-		exclusions = append(exclusions, nodeExclusion(node.Name, diag, explicit.Has(node.Name)))
+		exclusions = append(exclusions, nodeExclusion(node.Name, diag, narrowingPlugins, explicit.Has(node.Name)))
 	}
 	return exclusions
 }
 
-func nodeExclusion(nodeName string, diag *framework.Diagnosis, hasExplicitStatus bool) NodeExclusion {
+func nodeExclusion(nodeName string, diag *framework.Diagnosis, narrowingPlugins sets.Set[string], hasExplicitStatus bool) NodeExclusion {
 	unknown := NodeExclusion{NodeName: nodeName, Stage: RejectionStageUnknown}
 	if diag == nil || diag.NodeToStatus == nil {
 		return unknown
@@ -114,8 +121,6 @@ func nodeExclusion(nodeName string, diag *framework.Diagnosis, hasExplicitStatus
 	if status := diag.NodeToStatus.Get(nodeName); status != nil {
 		plugin = status.Plugin()
 	}
-	// ExtenderName is a pseudo-plugin marker, never a narrowing candidate.
-	narrowingPlugins := diag.UnschedulablePlugins.Difference(sets.New(framework.ExtenderName))
 	switch {
 	case hasExplicitStatus && plugin != "":
 		return NodeExclusion{NodeName: nodeName, Plugin: plugin, Stage: RejectionStageFilter}

--- a/pkg/upstreamsync/snapshot/exclusions.go
+++ b/pkg/upstreamsync/snapshot/exclusions.go
@@ -1,0 +1,136 @@
+// Copyright The Kubernetes Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package snapshot
+
+import (
+	"context"
+
+	v1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/util/sets"
+
+	fwk "k8s.io/kube-scheduler/framework"
+	"k8s.io/kubernetes/pkg/scheduler/framework"
+)
+
+// RejectionStage identifies the evaluation stage at which a node was rejected.
+type RejectionStage string
+
+const (
+	// RejectionStagePreFilter marks nodes rejected because a PreFilter plugin
+	// rejected the pod before any per-node evaluation.
+	RejectionStagePreFilter RejectionStage = "PreFilter"
+	// RejectionStagePreFilterNarrowing marks nodes removed by PreFilterResult
+	// candidate-set narrowing rather than an explicit per-node rejection.
+	RejectionStagePreFilterNarrowing RejectionStage = "PreFilterNarrowing"
+	// RejectionStageFilter marks nodes rejected by a Filter plugin.
+	RejectionStageFilter RejectionStage = "Filter"
+	// RejectionStageExtender marks nodes rejected by a scheduling extender.
+	RejectionStageExtender RejectionStage = "Extender"
+	// RejectionStageUnknown marks rejections for which the diagnosis carries
+	// no attribution data.
+	RejectionStageUnknown RejectionStage = "Unknown"
+)
+
+// NodeExclusion describes why a single placement node was rejected by a
+// feasibility check. Plugin is the rejecting plugin's registered name (as
+// reported by the scheduling framework) and is empty when the rejection
+// cannot be attributed to exactly one plugin; Stage is then the most specific
+// stage the diagnosis supports. The record is derived from typed Diagnosis
+// data only — status messages are never consulted, so the values are stable
+// across message-wording changes in the plugins.
+type NodeExclusion struct {
+	NodeName string
+	Plugin   string
+	Stage    RejectionStage
+}
+
+// CanSchedulePodWithExclusions is CanSchedulePod plus one structured
+// NodeExclusion record per rejected placement node, derived from the returned
+// Diagnosis via NodeExclusionsFromDiagnosis. The feasible-node result is
+// identical to CanSchedulePod's; on error no exclusions are derived.
+func (s *ClusterSnapshot) CanSchedulePodWithExclusions(ctx context.Context, pod *v1.Pod, placement *fwk.Placement) ([]string, []NodeExclusion, *framework.Diagnosis, error) {
+	feasibleNodes, diagnosis, err := s.CanSchedulePod(ctx, pod, placement)
+	if err != nil {
+		return feasibleNodes, nil, diagnosis, err
+	}
+	return feasibleNodes, NodeExclusionsFromDiagnosis(placement, feasibleNodes, diagnosis), diagnosis, nil
+}
+
+// NodeExclusionsFromDiagnosis derives one NodeExclusion per placement node
+// that is not in feasibleNodeNames, in placement order. It reads only typed
+// Diagnosis data and does not mutate the Diagnosis.
+//
+// Attribution follows how the framework populates the Diagnosis:
+//   - Filter plugins store an explicit per-node status tagged with the
+//     rejecting plugin's name.
+//   - A PreFilter plugin rejection is stored as the absent-nodes status, also
+//     tagged with the plugin name, covering every node without an explicit
+//     status.
+//   - PreFilterResult narrowing stores a plugin-less absent-nodes status and
+//     records the narrowing plugins in UnschedulablePlugins; a plugin is
+//     attributed only when exactly one is recorded.
+//   - Extenders store explicit plugin-less per-node statuses and add
+//     framework.ExtenderName to UnschedulablePlugins.
+func NodeExclusionsFromDiagnosis(placement *fwk.Placement, feasibleNodeNames []string, diag *framework.Diagnosis) []NodeExclusion {
+	if placement == nil || len(placement.Nodes) == 0 {
+		return nil
+	}
+	feasible := sets.New(feasibleNodeNames...)
+	explicit := sets.New[string]()
+	if diag != nil && diag.NodeToStatus != nil {
+		diag.NodeToStatus.ForEachExplicitNode(func(nodeName string, _ *fwk.Status) {
+			explicit.Insert(nodeName)
+		})
+	}
+	var exclusions []NodeExclusion
+	for _, nodeInfo := range placement.Nodes {
+		node := nodeInfo.Node()
+		if node == nil || feasible.Has(node.Name) {
+			continue
+		}
+		exclusions = append(exclusions, nodeExclusion(node.Name, diag, explicit.Has(node.Name)))
+	}
+	return exclusions
+}
+
+func nodeExclusion(nodeName string, diag *framework.Diagnosis, hasExplicitStatus bool) NodeExclusion {
+	unknown := NodeExclusion{NodeName: nodeName, Stage: RejectionStageUnknown}
+	if diag == nil || diag.NodeToStatus == nil {
+		return unknown
+	}
+	var plugin string
+	if status := diag.NodeToStatus.Get(nodeName); status != nil {
+		plugin = status.Plugin()
+	}
+	// ExtenderName is a pseudo-plugin marker, never a narrowing candidate.
+	narrowingPlugins := diag.UnschedulablePlugins.Difference(sets.New(framework.ExtenderName))
+	switch {
+	case hasExplicitStatus && plugin != "":
+		return NodeExclusion{NodeName: nodeName, Plugin: plugin, Stage: RejectionStageFilter}
+	case hasExplicitStatus:
+		if diag.UnschedulablePlugins.Has(framework.ExtenderName) {
+			return NodeExclusion{NodeName: nodeName, Stage: RejectionStageExtender}
+		}
+		return unknown
+	case plugin != "":
+		return NodeExclusion{NodeName: nodeName, Plugin: plugin, Stage: RejectionStagePreFilter}
+	case narrowingPlugins.Len() == 1:
+		return NodeExclusion{NodeName: nodeName, Plugin: narrowingPlugins.UnsortedList()[0], Stage: RejectionStagePreFilterNarrowing}
+	case narrowingPlugins.Len() > 1:
+		return NodeExclusion{NodeName: nodeName, Stage: RejectionStagePreFilterNarrowing}
+	default:
+		return unknown
+	}
+}

--- a/pkg/upstreamsync/snapshot/exclusions_test.go
+++ b/pkg/upstreamsync/snapshot/exclusions_test.go
@@ -1,0 +1,311 @@
+// Copyright The Kubernetes Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package snapshot
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+	v1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/sets"
+	st "k8s.io/kubernetes/pkg/scheduler/testing"
+
+	fwk "k8s.io/kube-scheduler/framework"
+	"k8s.io/kubernetes/pkg/scheduler/framework"
+)
+
+func testPlacement(nodeNames ...string) *fwk.Placement {
+	nodes := make([]fwk.NodeInfo, 0, len(nodeNames))
+	for _, name := range nodeNames {
+		ni := framework.NewNodeInfo()
+		ni.SetNode(&v1.Node{ObjectMeta: metav1.ObjectMeta{Name: name}})
+		nodes = append(nodes, ni)
+	}
+	return &fwk.Placement{Nodes: nodes}
+}
+
+func statusRejectedBy(plugin string) *fwk.Status {
+	return fwk.NewStatus(fwk.UnschedulableAndUnresolvable).WithPlugin(plugin)
+}
+
+func TestNodeExclusionsFromDiagnosis(t *testing.T) {
+	tests := []struct {
+		name      string
+		placement *fwk.Placement
+		feasible  []string
+		diag      *framework.Diagnosis
+		want      []NodeExclusion
+	}{
+		{
+			name:      "filter rejections attributed per plugin in placement order",
+			placement: testPlacement("n1", "n2", "n3", "n4"),
+			feasible:  []string{"n4"},
+			diag: func() *framework.Diagnosis {
+				nts := framework.NewDefaultNodeToStatus()
+				nts.Set("n1", statusRejectedBy("TaintToleration"))
+				nts.Set("n2", statusRejectedBy("TaintToleration"))
+				nts.Set("n3", statusRejectedBy("NodeAffinity"))
+				return &framework.Diagnosis{NodeToStatus: nts}
+			}(),
+			want: []NodeExclusion{
+				{NodeName: "n1", Plugin: "TaintToleration", Stage: RejectionStageFilter},
+				{NodeName: "n2", Plugin: "TaintToleration", Stage: RejectionStageFilter},
+				{NodeName: "n3", Plugin: "NodeAffinity", Stage: RejectionStageFilter},
+			},
+		},
+		{
+			name:      "prefilter plugin rejection covers all nodes via the absent status",
+			placement: testPlacement("n1", "n2"),
+			feasible:  nil,
+			diag: func() *framework.Diagnosis {
+				nts := framework.NewDefaultNodeToStatus()
+				nts.SetAbsentNodesStatus(statusRejectedBy("NodeAffinity"))
+				return &framework.Diagnosis{NodeToStatus: nts}
+			}(),
+			want: []NodeExclusion{
+				{NodeName: "n1", Plugin: "NodeAffinity", Stage: RejectionStagePreFilter},
+				{NodeName: "n2", Plugin: "NodeAffinity", Stage: RejectionStagePreFilter},
+			},
+		},
+		{
+			name:      "narrowing by exactly one plugin is attributed to it",
+			placement: testPlacement("n1", "n2"),
+			feasible:  nil,
+			diag: &framework.Diagnosis{
+				NodeToStatus:         framework.NewDefaultNodeToStatus(),
+				UnschedulablePlugins: sets.New("NodeAffinity"),
+			},
+			want: []NodeExclusion{
+				{NodeName: "n1", Plugin: "NodeAffinity", Stage: RejectionStagePreFilterNarrowing},
+				{NodeName: "n2", Plugin: "NodeAffinity", Stage: RejectionStagePreFilterNarrowing},
+			},
+		},
+		{
+			name:      "narrowing by several plugins is never guessed",
+			placement: testPlacement("n1"),
+			feasible:  nil,
+			diag: &framework.Diagnosis{
+				NodeToStatus:         framework.NewDefaultNodeToStatus(),
+				UnschedulablePlugins: sets.New("NodeAffinity", "OtherPlugin"),
+			},
+			want: []NodeExclusion{
+				{NodeName: "n1", Stage: RejectionStagePreFilterNarrowing},
+			},
+		},
+		{
+			name:      "extender rejections carry the extender stage without a plugin",
+			placement: testPlacement("n1", "n2"),
+			feasible:  []string{"n2"},
+			diag: func() *framework.Diagnosis {
+				nts := framework.NewDefaultNodeToStatus()
+				nts.Set("n1", fwk.NewStatus(fwk.UnschedulableAndUnresolvable))
+				return &framework.Diagnosis{
+					NodeToStatus:         nts,
+					UnschedulablePlugins: sets.New(framework.ExtenderName),
+				}
+			}(),
+			want: []NodeExclusion{
+				{NodeName: "n1", Stage: RejectionStageExtender},
+			},
+		},
+		{
+			name:      "extender marker does not masquerade as a narrowing plugin",
+			placement: testPlacement("n1", "n2"),
+			feasible:  nil,
+			diag: func() *framework.Diagnosis {
+				nts := framework.NewDefaultNodeToStatus()
+				nts.Set("n1", fwk.NewStatus(fwk.UnschedulableAndUnresolvable))
+				return &framework.Diagnosis{
+					NodeToStatus:         nts,
+					UnschedulablePlugins: sets.New(framework.ExtenderName, "NodeAffinity"),
+				}
+			}(),
+			want: []NodeExclusion{
+				{NodeName: "n1", Stage: RejectionStageExtender},
+				{NodeName: "n2", Plugin: "NodeAffinity", Stage: RejectionStagePreFilterNarrowing},
+			},
+		},
+		{
+			name:      "unknown plugin names pass through verbatim",
+			placement: testPlacement("n1"),
+			feasible:  nil,
+			diag: func() *framework.Diagnosis {
+				nts := framework.NewDefaultNodeToStatus()
+				nts.Set("n1", statusRejectedBy("SomeFuturePlugin"))
+				return &framework.Diagnosis{NodeToStatus: nts}
+			}(),
+			want: []NodeExclusion{
+				{NodeName: "n1", Plugin: "SomeFuturePlugin", Stage: RejectionStageFilter},
+			},
+		},
+		{
+			name:      "no diagnosis data yields unknown-stage records",
+			placement: testPlacement("n1", "n2"),
+			feasible:  nil,
+			diag:      nil,
+			want: []NodeExclusion{
+				{NodeName: "n1", Stage: RejectionStageUnknown},
+				{NodeName: "n2", Stage: RejectionStageUnknown},
+			},
+		},
+		{
+			name:      "all nodes feasible yields no records",
+			placement: testPlacement("n1", "n2"),
+			feasible:  []string{"n1", "n2"},
+			diag:      &framework.Diagnosis{NodeToStatus: framework.NewDefaultNodeToStatus()},
+			want:      nil,
+		},
+		{
+			name:      "nil placement yields no records",
+			placement: nil,
+			feasible:  nil,
+			diag:      &framework.Diagnosis{NodeToStatus: framework.NewDefaultNodeToStatus()},
+			want:      nil,
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			got := NodeExclusionsFromDiagnosis(tc.placement, tc.feasible, tc.diag)
+			if diff := cmp.Diff(tc.want, got); diff != "" {
+				t.Errorf("unexpected exclusions (-want +got):\n%s", diff)
+			}
+
+			rejected := 0
+			if tc.placement != nil {
+				feasibleSet := sets.New(tc.feasible...)
+				for _, ni := range tc.placement.Nodes {
+					if !feasibleSet.Has(ni.Node().Name) {
+						rejected++
+					}
+				}
+			}
+			if len(got) != rejected {
+				t.Errorf("got %d records for %d rejected nodes (every rejected node must have exactly one record)", len(got), rejected)
+			}
+
+			if again := NodeExclusionsFromDiagnosis(tc.placement, tc.feasible, tc.diag); !cmp.Equal(got, again) {
+				t.Errorf("derivation is not deterministic:\nfirst: %v\nsecond: %v", got, again)
+			}
+
+			if tc.diag != nil && tc.diag.NodeToStatus != nil {
+				lenBefore := tc.diag.NodeToStatus.Len()
+				_ = NodeExclusionsFromDiagnosis(tc.placement, tc.feasible, tc.diag)
+				if tc.diag.NodeToStatus.Len() != lenBefore {
+					t.Errorf("derivation mutated the diagnosis NodeToStatus (len %d -> %d)", lenBefore, tc.diag.NodeToStatus.Len())
+				}
+			}
+		})
+	}
+}
+
+func TestCanSchedulePodWithExclusions(t *testing.T) {
+	tests := []struct {
+		name           string
+		candidateNodes []string
+		podRequestCPU  string
+		expectNodes    []string
+		expectExcluded []NodeExclusion
+	}{
+		{
+			name:           "all nodes feasible yields no exclusions",
+			candidateNodes: []string{"node1", "node2"},
+			expectNodes:    []string{"node1", "node2"},
+			expectExcluded: nil,
+		},
+		{
+			name:           "filter rejection is attributed to the rejecting plugin",
+			candidateNodes: []string{"node1"},
+			podRequestCPU:  "1",
+			expectNodes:    []string{},
+			expectExcluded: []NodeExclusion{
+				{NodeName: "node1", Plugin: "NodeResourcesFit", Stage: RejectionStageFilter},
+			},
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			ctx := t.Context()
+
+			snapshotNodes := make([]*v1.Node, len(tc.candidateNodes))
+			for i, name := range tc.candidateNodes {
+				snapshotNodes[i] = st.MakeNode().Name(name).Capacity(map[v1.ResourceName]string{
+					v1.ResourceCPU:    "0",
+					v1.ResourceMemory: "0",
+					v1.ResourcePods:   "110",
+				}).Obj()
+			}
+			cs, _, _ := setupSnapshotTest(t, ctx, snapshotNodes, nil)
+
+			podBuilder := st.MakePod().Name("pod1").Namespace("default").UID("uid-pod1")
+			if tc.podRequestCPU != "" {
+				podBuilder = podBuilder.Req(map[v1.ResourceName]string{v1.ResourceCPU: tc.podRequestCPU})
+			}
+			pod := podBuilder.Obj()
+
+			placement, err := cs.MakePlacement(tc.candidateNodes)
+			if err != nil {
+				t.Fatalf("MakePlacement() error = %v", err)
+			}
+
+			feasible, exclusions, _, err := cs.CanSchedulePodWithExclusions(ctx, pod, placement)
+			if err != nil {
+				t.Fatalf("CanSchedulePodWithExclusions() error = %v", err)
+			}
+
+			plainFeasible, _, err := cs.CanSchedulePod(ctx, pod, placement)
+			if err != nil {
+				t.Fatalf("CanSchedulePod() error = %v", err)
+			}
+			if diff := cmp.Diff(plainFeasible, feasible); diff != "" {
+				t.Errorf("feasible nodes differ from CanSchedulePod (-plain +withExclusions):\n%s", diff)
+			}
+			if diff := cmp.Diff(tc.expectNodes, feasible); diff != "" {
+				t.Errorf("unexpected feasible nodes (-want +got):\n%s", diff)
+			}
+			if diff := cmp.Diff(tc.expectExcluded, exclusions); diff != "" {
+				t.Errorf("unexpected exclusions (-want +got):\n%s", diff)
+			}
+		})
+	}
+}
+
+func BenchmarkNodeExclusionsFromDiagnosis(b *testing.B) {
+	const numNodes = 1000
+	nodeNames := make([]string, numNodes)
+	for i := range numNodes {
+		nodeNames[i] = fmt.Sprintf("node-%d", i)
+	}
+	placement := testPlacement(nodeNames...)
+	nts := framework.NewDefaultNodeToStatus()
+	for i, name := range nodeNames {
+		switch i % 3 {
+		case 0:
+			nts.Set(name, statusRejectedBy("TaintToleration"))
+		case 1:
+			nts.Set(name, statusRejectedBy("NodeAffinity"))
+			// case 2: resolved through the absent status.
+		}
+	}
+	nts.SetAbsentNodesStatus(statusRejectedBy("NodeAffinity"))
+	diag := &framework.Diagnosis{NodeToStatus: nts}
+
+	for b.Loop() {
+		if got := NodeExclusionsFromDiagnosis(placement, nil, diag); len(got) != numNodes {
+			b.Fatalf("expected %d records, got %d", numNodes, len(got))
+		}
+	}
+}

--- a/pkg/upstreamsync/snapshot/exclusions_test.go
+++ b/pkg/upstreamsync/snapshot/exclusions_test.go
@@ -49,6 +49,7 @@ func TestNodeExclusionsFromDiagnosis(t *testing.T) {
 		placement *fwk.Placement
 		feasible  []string
 		diag      *framework.Diagnosis
+		narrowing sets.Set[string]
 		want      []NodeExclusion
 	}{
 		{
@@ -90,6 +91,7 @@ func TestNodeExclusionsFromDiagnosis(t *testing.T) {
 				NodeToStatus:         framework.NewDefaultNodeToStatus(),
 				UnschedulablePlugins: sets.New("NodeAffinity"),
 			},
+			narrowing: sets.New("NodeAffinity"),
 			want: []NodeExclusion{
 				{NodeName: "n1", Plugin: "NodeAffinity", Stage: RejectionStagePreFilterNarrowing},
 				{NodeName: "n2", Plugin: "NodeAffinity", Stage: RejectionStagePreFilterNarrowing},
@@ -103,8 +105,45 @@ func TestNodeExclusionsFromDiagnosis(t *testing.T) {
 				NodeToStatus:         framework.NewDefaultNodeToStatus(),
 				UnschedulablePlugins: sets.New("NodeAffinity", "OtherPlugin"),
 			},
+			narrowing: sets.New("NodeAffinity", "OtherPlugin"),
 			want: []NodeExclusion{
 				{NodeName: "n1", Stage: RejectionStagePreFilterNarrowing},
+			},
+		},
+		{
+			// UnschedulablePlugins accumulates Filter-rejecting plugins on top
+			// of the narrowing ones, so attribution must come from the
+			// narrowing set captured before Filter ran.
+			name:      "filter pollution of UnschedulablePlugins does not break narrowing attribution",
+			placement: testPlacement("n1", "n2"),
+			feasible:  nil,
+			diag: func() *framework.Diagnosis {
+				nts := framework.NewDefaultNodeToStatus()
+				nts.Set("n1", statusRejectedBy("NodeResourcesFit"))
+				return &framework.Diagnosis{
+					NodeToStatus:         nts,
+					UnschedulablePlugins: sets.New("NodeAffinity", "NodeResourcesFit"),
+				}
+			}(),
+			narrowing: sets.New("NodeAffinity"),
+			want: []NodeExclusion{
+				{NodeName: "n1", Plugin: "NodeResourcesFit", Stage: RejectionStageFilter},
+				{NodeName: "n2", Plugin: "NodeAffinity", Stage: RejectionStagePreFilterNarrowing},
+			},
+		},
+		{
+			// Without the captured set the derivation must not guess from the
+			// polluted UnschedulablePlugins.
+			name:      "nil narrowing set yields unknown-stage records",
+			placement: testPlacement("n1"),
+			feasible:  nil,
+			diag: &framework.Diagnosis{
+				NodeToStatus:         framework.NewDefaultNodeToStatus(),
+				UnschedulablePlugins: sets.New("NodeAffinity"),
+			},
+			narrowing: nil,
+			want: []NodeExclusion{
+				{NodeName: "n1", Stage: RejectionStageUnknown},
 			},
 		},
 		{
@@ -135,6 +174,7 @@ func TestNodeExclusionsFromDiagnosis(t *testing.T) {
 					UnschedulablePlugins: sets.New(framework.ExtenderName, "NodeAffinity"),
 				}
 			}(),
+			narrowing: sets.New("NodeAffinity"),
 			want: []NodeExclusion{
 				{NodeName: "n1", Stage: RejectionStageExtender},
 				{NodeName: "n2", Plugin: "NodeAffinity", Stage: RejectionStagePreFilterNarrowing},
@@ -180,7 +220,7 @@ func TestNodeExclusionsFromDiagnosis(t *testing.T) {
 	}
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
-			got := NodeExclusionsFromDiagnosis(tc.placement, tc.feasible, tc.diag)
+			got := NodeExclusionsFromDiagnosis(tc.placement, tc.feasible, tc.diag, tc.narrowing)
 			if diff := cmp.Diff(tc.want, got); diff != "" {
 				t.Errorf("unexpected exclusions (-want +got):\n%s", diff)
 			}
@@ -198,13 +238,13 @@ func TestNodeExclusionsFromDiagnosis(t *testing.T) {
 				t.Errorf("got %d records for %d rejected nodes (every rejected node must have exactly one record)", len(got), rejected)
 			}
 
-			if again := NodeExclusionsFromDiagnosis(tc.placement, tc.feasible, tc.diag); !cmp.Equal(got, again) {
+			if again := NodeExclusionsFromDiagnosis(tc.placement, tc.feasible, tc.diag, tc.narrowing); !cmp.Equal(got, again) {
 				t.Errorf("derivation is not deterministic:\nfirst: %v\nsecond: %v", got, again)
 			}
 
 			if tc.diag != nil && tc.diag.NodeToStatus != nil {
 				lenBefore := tc.diag.NodeToStatus.Len()
-				_ = NodeExclusionsFromDiagnosis(tc.placement, tc.feasible, tc.diag)
+				_ = NodeExclusionsFromDiagnosis(tc.placement, tc.feasible, tc.diag, tc.narrowing)
 				if tc.diag.NodeToStatus.Len() != lenBefore {
 					t.Errorf("derivation mutated the diagnosis NodeToStatus (len %d -> %d)", lenBefore, tc.diag.NodeToStatus.Len())
 				}
@@ -218,6 +258,7 @@ func TestCanSchedulePodWithExclusions(t *testing.T) {
 		name           string
 		candidateNodes []string
 		podRequestCPU  string
+		nodeCPU        map[string]string
 		nodeAffinity   *v1.NodeAffinity
 		expectNodes    []string
 		expectExcluded []NodeExclusion
@@ -257,6 +298,30 @@ func TestCanSchedulePodWithExclusions(t *testing.T) {
 			},
 		},
 		{
+			// Narrowing coexisting with a Filter rejection: node1 is in the
+			// narrowed set but lacks CPU, so NodeResourcesFit rejects it and
+			// pollutes Diagnosis.UnschedulablePlugins; node2's narrowing must
+			// still be attributed to NodeAffinity from the captured set.
+			name:           "narrowing mixed with a filter rejection stays attributed",
+			candidateNodes: []string{"node1", "node2"},
+			podRequestCPU:  "1",
+			nodeCPU:        map[string]string{"node2": "1"},
+			nodeAffinity: &v1.NodeAffinity{
+				RequiredDuringSchedulingIgnoredDuringExecution: &v1.NodeSelector{
+					NodeSelectorTerms: []v1.NodeSelectorTerm{{
+						MatchFields: []v1.NodeSelectorRequirement{
+							{Key: metav1.ObjectNameField, Operator: v1.NodeSelectorOpIn, Values: []string{"node1"}},
+						},
+					}},
+				},
+			},
+			expectNodes: []string{},
+			expectExcluded: []NodeExclusion{
+				{NodeName: "node1", Plugin: "NodeResourcesFit", Stage: RejectionStageFilter},
+				{NodeName: "node2", Plugin: "NodeAffinity", Stage: RejectionStagePreFilterNarrowing},
+			},
+		},
+		{
 			// Two non-intersecting metadata.name requirements in one term make
 			// NodeAffinity.PreFilter reject the pod outright for every node.
 			name:           "prefilter rejection is attributed to the rejecting plugin",
@@ -284,8 +349,12 @@ func TestCanSchedulePodWithExclusions(t *testing.T) {
 
 			snapshotNodes := make([]*v1.Node, len(tc.candidateNodes))
 			for i, name := range tc.candidateNodes {
+				cpu := "0"
+				if v, ok := tc.nodeCPU[name]; ok {
+					cpu = v
+				}
 				snapshotNodes[i] = st.MakeNode().Name(name).Capacity(map[v1.ResourceName]string{
-					v1.ResourceCPU:    "0",
+					v1.ResourceCPU:    cpu,
 					v1.ResourceMemory: "0",
 					v1.ResourcePods:   "110",
 				}).Obj()
@@ -358,7 +427,7 @@ func BenchmarkNodeExclusionsFromDiagnosis(b *testing.B) {
 	diag := &framework.Diagnosis{NodeToStatus: nts}
 
 	for b.Loop() {
-		if got := NodeExclusionsFromDiagnosis(placement, nil, diag); len(got) != numNodes {
+		if got := NodeExclusionsFromDiagnosis(placement, nil, diag, nil); len(got) != numNodes {
 			b.Fatalf("expected %d records, got %d", numNodes, len(got))
 		}
 	}

--- a/pkg/upstreamsync/snapshot/exclusions_test.go
+++ b/pkg/upstreamsync/snapshot/exclusions_test.go
@@ -19,6 +19,7 @@ import (
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
+	"github.com/google/go-cmp/cmp/cmpopts"
 	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/sets"
@@ -266,14 +267,21 @@ func TestCanSchedulePodWithExclusions(t *testing.T) {
 				t.Fatalf("CanSchedulePodWithExclusions() error = %v", err)
 			}
 
+			// CanSchedulePod filters nodes in parallel, so the feasible list
+			// has no guaranteed order — compare order-insensitively, like
+			// TestCanSchedulePod does.
+			feasibleCmpOpts := []cmp.Option{
+				cmpopts.EquateEmpty(),
+				cmpopts.SortSlices(func(x, y string) bool { return x < y }),
+			}
 			plainFeasible, _, err := cs.CanSchedulePod(ctx, pod, placement)
 			if err != nil {
 				t.Fatalf("CanSchedulePod() error = %v", err)
 			}
-			if diff := cmp.Diff(plainFeasible, feasible); diff != "" {
+			if diff := cmp.Diff(plainFeasible, feasible, feasibleCmpOpts...); diff != "" {
 				t.Errorf("feasible nodes differ from CanSchedulePod (-plain +withExclusions):\n%s", diff)
 			}
-			if diff := cmp.Diff(tc.expectNodes, feasible); diff != "" {
+			if diff := cmp.Diff(tc.expectNodes, feasible, feasibleCmpOpts...); diff != "" {
 				t.Errorf("unexpected feasible nodes (-want +got):\n%s", diff)
 			}
 			if diff := cmp.Diff(tc.expectExcluded, exclusions); diff != "" {

--- a/pkg/upstreamsync/snapshot/exclusions_test.go
+++ b/pkg/upstreamsync/snapshot/exclusions_test.go
@@ -218,6 +218,7 @@ func TestCanSchedulePodWithExclusions(t *testing.T) {
 		name           string
 		candidateNodes []string
 		podRequestCPU  string
+		nodeAffinity   *v1.NodeAffinity
 		expectNodes    []string
 		expectExcluded []NodeExclusion
 	}{
@@ -234,6 +235,46 @@ func TestCanSchedulePodWithExclusions(t *testing.T) {
 			expectNodes:    []string{},
 			expectExcluded: []NodeExclusion{
 				{NodeName: "node1", Plugin: "NodeResourcesFit", Stage: RejectionStageFilter},
+			},
+		},
+		{
+			// A metadata.name affinity makes NodeAffinity.PreFilter return a
+			// PreFilterResult, so node2 is narrowed out before Filter runs.
+			name:           "prefilter narrowing is attributed to the narrowing plugin",
+			candidateNodes: []string{"node1", "node2"},
+			nodeAffinity: &v1.NodeAffinity{
+				RequiredDuringSchedulingIgnoredDuringExecution: &v1.NodeSelector{
+					NodeSelectorTerms: []v1.NodeSelectorTerm{{
+						MatchFields: []v1.NodeSelectorRequirement{
+							{Key: metav1.ObjectNameField, Operator: v1.NodeSelectorOpIn, Values: []string{"node1"}},
+						},
+					}},
+				},
+			},
+			expectNodes: []string{"node1"},
+			expectExcluded: []NodeExclusion{
+				{NodeName: "node2", Plugin: "NodeAffinity", Stage: RejectionStagePreFilterNarrowing},
+			},
+		},
+		{
+			// Two non-intersecting metadata.name requirements in one term make
+			// NodeAffinity.PreFilter reject the pod outright for every node.
+			name:           "prefilter rejection is attributed to the rejecting plugin",
+			candidateNodes: []string{"node1", "node2"},
+			nodeAffinity: &v1.NodeAffinity{
+				RequiredDuringSchedulingIgnoredDuringExecution: &v1.NodeSelector{
+					NodeSelectorTerms: []v1.NodeSelectorTerm{{
+						MatchFields: []v1.NodeSelectorRequirement{
+							{Key: metav1.ObjectNameField, Operator: v1.NodeSelectorOpIn, Values: []string{"node1"}},
+							{Key: metav1.ObjectNameField, Operator: v1.NodeSelectorOpIn, Values: []string{"node2"}},
+						},
+					}},
+				},
+			},
+			expectNodes: []string{},
+			expectExcluded: []NodeExclusion{
+				{NodeName: "node1", Plugin: "NodeAffinity", Stage: RejectionStagePreFilter},
+				{NodeName: "node2", Plugin: "NodeAffinity", Stage: RejectionStagePreFilter},
 			},
 		},
 	}
@@ -255,6 +296,9 @@ func TestCanSchedulePodWithExclusions(t *testing.T) {
 			if tc.podRequestCPU != "" {
 				podBuilder = podBuilder.Req(map[v1.ResourceName]string{v1.ResourceCPU: tc.podRequestCPU})
 			}
+			if tc.nodeAffinity != nil {
+				podBuilder = podBuilder.NodeAffinity(tc.nodeAffinity)
+			}
 			pod := podBuilder.Obj()
 
 			placement, err := cs.MakePlacement(tc.candidateNodes)
@@ -267,9 +311,11 @@ func TestCanSchedulePodWithExclusions(t *testing.T) {
 				t.Fatalf("CanSchedulePodWithExclusions() error = %v", err)
 			}
 
-			// CanSchedulePod filters nodes in parallel, so the feasible list
-			// has no guaranteed order — compare order-insensitively, like
-			// TestCanSchedulePod does.
+			// Only the feasible-node list is compared order-insensitively (the
+			// SortSlices option below applies to []string only): CanSchedulePod
+			// filters nodes in parallel, so that list has no guaranteed order,
+			// whereas the NodeExclusion records are placement-ordered by
+			// contract and are compared strictly.
 			feasibleCmpOpts := []cmp.Option{
 				cmpopts.EquateEmpty(),
 				cmpopts.SortSlices(func(x, y string) bool { return x < y }),

--- a/pkg/upstreamsync/snapshot/snapshot.go
+++ b/pkg/upstreamsync/snapshot/snapshot.go
@@ -23,6 +23,7 @@ import (
 	"slices"
 
 	v1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/util/sets"
 	"k8s.io/klog/v2"
 	"sigs.k8s.io/scheduler-library/pkg/upstreamsync"
 
@@ -159,17 +160,25 @@ func (s *ClusterSnapshot) Transaction(ctx context.Context, transactionFn func() 
 // PreFilter and Filter plugins. Returns the names of nodes on which the pod can be scheduled,
 // the framework.Diagnosis for rejected nodes, and any error.
 func (s *ClusterSnapshot) CanSchedulePod(ctx context.Context, pod *v1.Pod, placement *fwk.Placement) ([]string, *framework.Diagnosis, error) {
+	feasibleNodes, _, diagnosis, err := s.canSchedulePod(ctx, pod, placement)
+	return feasibleNodes, diagnosis, err
+}
+
+// canSchedulePod additionally returns the narrowing plugins captured after
+// PreFilter and before Filter, when Diagnosis.UnschedulablePlugins is still
+// precise; Filter rejections are added to that set as evaluation proceeds.
+func (s *ClusterSnapshot) canSchedulePod(ctx context.Context, pod *v1.Pod, placement *fwk.Placement) ([]string, sets.Set[string], *framework.Diagnosis, error) {
 	if placement == nil || len(placement.Nodes) == 0 {
-		return nil, nil, nil
+		return nil, nil, nil, nil
 	}
 	schedFramework, err := s.profiles.FrameworkForPod(pod)
 	if err != nil {
-		return nil, nil, fmt.Errorf("failed to get framework: %w", err)
+		return nil, nil, nil, fmt.Errorf("failed to get framework: %w", err)
 	}
 	state := framework.NewCycleState()
 	podInfo, err := framework.NewPodInfo(pod)
 	if err != nil {
-		return nil, nil, fmt.Errorf("failed to create pod info: %w", err)
+		return nil, nil, nil, fmt.Errorf("failed to create pod info: %w", err)
 	}
 	pendingPod := &upstreamsync.PendingPod{
 		PodInfo:    podInfo,
@@ -181,19 +190,19 @@ func (s *ClusterSnapshot) CanSchedulePod(ctx context.Context, pod *v1.Pod, place
 	sched := upstreamsync.NewScheduler(s.schedulerSnapshot, 0, 0, math.MaxInt32)
 	err = s.schedulerSnapshot.AssumePlacement(placement)
 	if err != nil {
-		return nil, nil, fmt.Errorf("failed to assume placement: %w", err)
+		return nil, nil, nil, fmt.Errorf("failed to assume placement: %w", err)
 	}
 	defer s.schedulerSnapshot.ForgetPlacement()
-	nodes, diag, _, err := sched.FindAllNodesThatFitPod(ctx, schedFramework, pendingPod)
+	nodes, diag, narrowingPlugins, _, err := sched.FindAllNodesThatFitPod(ctx, schedFramework, pendingPod)
 	diagnosis = diag
 	for _, node := range nodes {
 		feasibleNodes = append(feasibleNodes, node.Node().Name)
 	}
 	if err != nil {
-		return nil, &diagnosis, fmt.Errorf("failed to find nodes that fit pod: %w", err)
+		return nil, narrowingPlugins, &diagnosis, fmt.Errorf("failed to find nodes that fit pod: %w", err)
 	}
 
-	return feasibleNodes, &diagnosis, nil
+	return feasibleNodes, narrowingPlugins, &diagnosis, nil
 }
 
 func schedulingResult(algRes *upstreamsync.AlgorithmResult) SchedulingResult {


### PR DESCRIPTION
#### What this PR does / why we need it:

Consumers of `ClusterSnapshot.CanSchedulePod` that want to report why each node was
rejected currently have to reverse-engineer the returned `*framework.Diagnosis`: which
rejection paths store explicit per-node statuses, which carry `Status.Plugin()`, which
fall back to the absent-nodes status, and which record identities only in
`UnschedulablePlugins`. Those are version-dependent framework internals, and the
human-readable messages carry no stability guarantee.

This PR makes the library the single owner of that knowledge, with a small additive API
in `pkg/upstreamsync/snapshot`:

- `NodeExclusion{NodeName, Plugin, Stage}` + `RejectionStage`
  (`PreFilter`, `PreFilterNarrowing`, `Filter`, `Extender`, `Unknown`);
- `NodeExclusionsFromDiagnosis(placement, feasibleNodeNames, diag)` , pure,
  deterministic (placement order), non-mutating derivation: one record per rejected
  node, none for feasible nodes;
- `(*ClusterSnapshot).CanSchedulePodWithExclusions(...)` , `CanSchedulePod` plus the
  derived records in one call, so a Diagnosis can never be paired with the wrong node
  set.

Attribution rules (each unit-tested): explicit status with plugin → `Filter`; absent
status with plugin → `PreFilter`; plugin-less absent status with exactly one narrowing
plugin recorded → that plugin at `PreFilterNarrowing` (never guessed among several);
explicit plugin-less status under the `ExtenderName` marker → `Extender`; otherwise
`Unknown`, with the node still accounted for. Unknown/custom plugin names pass through
verbatim. `CanSchedulePod` and every other existing signature are unchanged.

First consumer: Kueue's Topology-Aware Scheduling (kubernetes-sigs/kueue#13283)
currently ships an in-tree stopgap doing this derivation itself, marked `TODO(#13283)`
for replacement by this API.


#### Which issue(s) this PR fixes:

Fixes #15 

#### Special notes for your reviewer:
- Open design question carried from the issue: is per-plugin attribution the right
  granularity ceiling, or should the record grow fields for finer detail (specific
  taint, selector-vs-affinity)? The struct is additive-friendly either way.
  
  
 Disclosure: developed with AI assistance (Claude); design and code human-reviewed.
