### PR TITLE
Document the library surface and mark upstream divergences

### DIFF
--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -9,3 +9,8 @@ linters:
   settings:
     goheader:
       template-path: ${config-path}/hack/boilerplate.txt
+
+formatters:
+  enable:
+    - gofmt
+    - goimports

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -36,7 +36,7 @@ Any logic duplicated from the Kubernetes scheduler (e.g. to export internal code
 
 ### Marking divergences from upstream
 
-Copied code must keep the upstream doc comments verbatim, so that a copy can be diffed against its origin without guessing which comments were rewritten.
+Copied code must keep the upstream doc comments verbatim, so that a copy can be diffed against its origin without guessing which contents were rewritten.
 
 Every intentional deviation from upstream must be called out with a comment starting with the `UPSTREAM-DIFF:` prefix, stating what changed and why. Put it on the declaration when the whole function differs, or on the specific line otherwise. Listing everything that has to be reconciled before upstreaming is then a single command:
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -34,6 +34,16 @@ Our long-term goal is to migrate this simulation logic into the core Kubernetes 
 
 Any logic duplicated from the Kubernetes scheduler (e.g. to export internal code) must be placed in a dedicated package named `/pkg/upstreamsync`. Treat this code as "temporary debt" and include a comment in the code with a link to the upstream PR that will remove this code.
 
+### Marking divergences from upstream
+
+Copied code must keep the upstream doc comments verbatim, so that a copy can be diffed against its origin without guessing which comments were rewritten.
+
+Every intentional deviation from upstream must be called out with a comment starting with the `UPSTREAM-DIFF:` prefix, stating what changed and why. Put it on the declaration when the whole function differs, or on the specific line otherwise. Listing everything that has to be reconciled before upstreaming is then a single command:
+
+```sh
+grep -rn "UPSTREAM-DIFF:" pkg/
+```
+
 ### Synchronous upstreaming
 
 We discourage an “eventually” mindset. Any change to core scheduling logic in this library should trigger a parallel contribution to the upstream Kubernetes scheduler.

--- a/README.md
+++ b/README.md
@@ -12,6 +12,17 @@ This library allows you to create a frozen, in-memory view of a cluster (`Cluste
 * `ClusterState`: Reflects the real, runtime state of the cluster. It serves as the primary source for initializing snapshots.
 * `SchedulingSimulator`: The primary interface for creating snapshots and managing cluster states.
 
+## Entry points
+
+Everything a consumer needs is reachable from the [`pkg/simulator`](pkg/simulator) package, which documents the full flow:
+
+1. `simulator.NewReadonlyClient(restConfig)` — the only client type the library accepts; its transport rejects mutating requests.
+2. `simulator.NewSchedulingSimulator(ctx, cfg, client, informerFactory)` — created once and reused.
+3. `SchedulingSimulator.NewClusterState(ctx)` (live cluster state) or `SchedulingSimulator.NewClusterSnapshot(ctx, pods, nodes)` (explicit state).
+4. `ClusterSnapshot.MakePlacement`, `CanSchedulePod`, `SchedulePods`, `SchedulePodsByTemplate`, `PreemptPods`, `Unpreempt` and `Transaction` — the simulation methods.
+
+The remaining packages are implementation detail: `pkg/upstreamsync` holds logic duplicated from (or destined for) the upstream kube-scheduler, and `pkg/framework` wires the upstream scheduler framework for in-memory use.
+
 ## Key capabilities
 
 * **Transaction Support**: Execute sequences of mutations (e.g., preemptions, scheduling) with the ability to commit or revert changes. This supports complex branching scenarios during simulation.

--- a/pkg/framework/framework.go
+++ b/pkg/framework/framework.go
@@ -32,8 +32,29 @@ import (
 	"sigs.k8s.io/scheduler-library/pkg/upstreamsync"
 )
 
+// InitMetricsOnce constructs the kube-scheduler metric objects. They are package-level variables
+// that stay nil until metrics.InitMetrics is called, and the framework and the plugins record into
+// them unconditionally, so they have to be initialized before any framework is built or the first
+// recording panics.
+//
+// The initialization is process-wide, while a process may create many ProfileMaps (e.g. one per
+// SchedulingSimulator), each having to make sure the metrics exist without knowing about the
+// others. sync.OnceFunc lets them all call it while the metric objects are only ever built once,
+// so the values recorded so far are not thrown away by a later initialization.
 var InitMetricsOnce = sync.OnceFunc(metrics.InitMetrics)
 
+// NewProfileMap builds the scheduling profiles (one framework.Framework per scheduler name)
+// used by the library to run the scheduling cycle in memory.
+//
+// It wires the upstream framework with the no-op implementations of the extension points that
+// only make sense for a real, cluster-connected scheduler: events are discarded, pods are never
+// nominated nor activated and no API calls are issued. This keeps the simulation purely in-memory
+// while still running the very same plugins as kube-scheduler.
+//
+// The client is used by the plugins and the informers to read the cluster state; it must never be
+// allowed to mutate it (see simulator.ReadonlyClient). The snap is shared with all the built
+// frameworks, so mutating it in place is immediately visible to every plugin.
+// A nil informerFactory makes the function create one, and a nil cfg selects the default profile.
 func NewProfileMap(ctx context.Context, client kubernetes.Interface, informerFactory informers.SharedInformerFactory, snap *cache.Snapshot, cfg *schedulerapi.KubeSchedulerConfiguration) (*upstreamsync.ProfileMap, error) {
 	InitMetricsOnce()
 
@@ -63,6 +84,9 @@ func NewProfileMap(ctx context.Context, client kubernetes.Interface, informerFac
 	)
 }
 
+// discardEventRecorder drops all the events emitted by the plugins.
+// Simulations run against a read-only view of the cluster, so they must not
+// report anything back to the API server.
 type discardEventRecorder struct{}
 
 var _ events.EventRecorderLogger = &discardEventRecorder{}
@@ -74,6 +98,9 @@ func (d *discardEventRecorder) WithLogger(logger klog.Logger) events.EventRecord
 	return d
 }
 
+// noopPodNominator ignores all the nominations. Nomination is a kube-scheduler mechanism for
+// reserving a node for a pod awaiting preemption across scheduling cycles. The library has no
+// scheduling queue and exposes preemption explicitly so there is nothing to nominate to.
 type noopPodNominator struct{}
 
 var _ fwk.PodNominator = &noopPodNominator{}
@@ -87,12 +114,17 @@ func (n *noopPodNominator) NominatedPodsForNode(nodeName string) []fwk.PodInfo {
 	return nil
 }
 
+// noopPodActivator ignores all the requests to move pods back to the active queue,
+// as the library has no scheduling queue.
 type noopPodActivator struct{}
 
 var _ fwk.PodActivator = &noopPodActivator{}
 
 func (a *noopPodActivator) Activate(logger klog.Logger, pods map[string]*v1.Pod) {}
 
+// noopAPICacher pretends that every asynchronous API call the plugins request has already
+// succeeded, without ever contacting the API server. Simulations must not mutate the cluster,
+// so binding a pod or patching its status is reported as an immediately completed no-op.
 type noopAPICacher struct{}
 
 var _ fwk.APICacher = &noopAPICacher{}

--- a/pkg/framework/testing/snapshot_cmp.go
+++ b/pkg/framework/testing/snapshot_cmp.go
@@ -19,11 +19,13 @@ import (
 
 	"github.com/google/go-cmp/cmp"
 	"github.com/google/go-cmp/cmp/cmpopts"
+	"k8s.io/apimachinery/pkg/util/sets"
 	"k8s.io/kubernetes/pkg/scheduler/backend/cache"
 )
 
-// VerifySnapshot asserts which pods the snapshot has on which node.
-func VerifySnapshot(t *testing.T, snap *cache.Snapshot, expectedNodePods map[string][]string) {
+// VerifySnapshot asserts which pods the snapshot has on which node. The pods are compared as sets,
+// as the order in which a node lists them is not part of the contract.
+func VerifySnapshot(t *testing.T, snap *cache.Snapshot, expectedNodePods map[string]sets.Set[string]) {
 	t.Helper()
 	if snap == nil {
 		t.Fatal("Expected snapshot to be non-nil")
@@ -34,22 +36,22 @@ func VerifySnapshot(t *testing.T, snap *cache.Snapshot, expectedNodePods map[str
 		t.Fatalf("Failed to list nodes: %v", err)
 	}
 
-	gotNodePods := make(map[string][]string)
+	gotNodePods := make(map[string]sets.Set[string])
 	for _, n := range nodeList {
 		if n.Node() == nil {
 			continue
 		}
 		nodeName := n.Node().Name
-		var pods []string
+		pods := sets.New[string]()
 		for _, pInfo := range n.GetPods() {
 			if pInfo != nil && pInfo.GetPod() != nil {
-				pods = append(pods, pInfo.GetPod().Name)
+				pods.Insert(pInfo.GetPod().Name)
 			}
 		}
 		gotNodePods[nodeName] = pods
 	}
 
-	if diff := cmp.Diff(expectedNodePods, gotNodePods, cmpopts.EquateEmpty(), cmpopts.SortSlices(func(x, y string) bool { return x < y })); diff != "" {
+	if diff := cmp.Diff(expectedNodePods, gotNodePods, cmpopts.EquateEmpty()); diff != "" {
 		t.Errorf("Unexpected snapshot nodePods (-want +got):\n%s", diff)
 	}
 }

--- a/pkg/framework/testing/snapshot_cmp.go
+++ b/pkg/framework/testing/snapshot_cmp.go
@@ -22,6 +22,7 @@ import (
 	"k8s.io/kubernetes/pkg/scheduler/backend/cache"
 )
 
+// VerifySnapshot asserts which pods the snapshot has on which node.
 func VerifySnapshot(t *testing.T, snap *cache.Snapshot, expectedNodePods map[string][]string) {
 	t.Helper()
 	if snap == nil {
@@ -53,6 +54,8 @@ func VerifySnapshot(t *testing.T, snap *cache.Snapshot, expectedNodePods map[str
 	}
 }
 
+// VerifySnapshotPodCounts asserts how many pods the snapshot has on each node, for the cases where
+// the pod names are not known upfront.
 func VerifySnapshotPodCounts(t *testing.T, snap *cache.Snapshot, expectedCounts map[string]int) {
 	t.Helper()
 	if snap == nil {

--- a/pkg/simulator/doc.go
+++ b/pkg/simulator/doc.go
@@ -35,21 +35,34 @@
 // # Obtaining a snapshot
 //
 // A snapshot.ClusterSnapshot is an in-memory, mutable view of the cluster that all the
-// simulation runs against. There are two ways to get one:
+// simulation runs against. These two are the only supported ways to get one:
 //
 //   - SchedulingSimulator.NewClusterState followed by state.ClusterState.Snapshot, when the
-//     simulation should start from the live cluster state. ClusterState.Cache is fed from the
-//     consumer's informers/event handlers and Snapshot freezes it.
+//     simulation should start from the live cluster state (see "Tracking the cluster" below).
 //   - SchedulingSimulator.NewClusterSnapshot, when the simulation should start from an
-//     explicitly provided set of pods and nodes.
+//     explicitly provided set of pods and nodes. Those are the whole world for that snapshot:
+//     reflecting a later change means asking for a new one.
 //
-// Prefer these constructors over building a snapshot.ClusterSnapshot directly: they are the ones
-// that register the metrics and build the full plugin chain out of the KubeSchedulerConfiguration.
+// Assembling a ClusterSnapshot by hand is not an option: all of its fields are unexported, and
+// snapshot.New — exported only because pkg/state builds on it — takes an already built profile
+// map and assumes the scheduler metrics are registered. The two entry points above are what
+// builds the plugin chain out of the KubeSchedulerConfiguration and registers those metrics.
+//
+// # Tracking the cluster
+//
+// ClusterState is long-lived and is meant to follow the real cluster: its Cache is the upstream
+// scheduler cache, fed by the consumer from its own informers or event handlers
+// (AddPod/UpdatePod/RemovePod, AddNode/UpdateNode/RemoveNode). Each ClusterState.Snapshot call
+// then folds the accumulated changes in incrementally instead of rebuilding the view from
+// scratch, which is what makes keeping a long-running simulation up to date cheap.
+//
+// The changes are applied in place, to the snapshot shared by all the scheduling profiles, so a
+// ClusterSnapshot obtained from an earlier Snapshot call must not be used afterwards.
 //
 // # Simulating
 //
-// All the simulation methods live on *snapshot.ClusterSnapshot and are the methods a consumer is
-// expected to call:
+// All the simulation methods live on *snapshot.ClusterSnapshot and are gathered in the Simulator
+// interface, which is what NewClusterSnapshot returns:
 //
 //   - MakePlacement turns node names into the *fwk.Placement that the other methods restrict
 //     the simulation to.

--- a/pkg/simulator/doc.go
+++ b/pkg/simulator/doc.go
@@ -1,0 +1,74 @@
+// Copyright The Kubernetes Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package simulator is the entry point of the scheduler library.
+//
+// Everything a consumer needs is reachable from SchedulingSimulator; the other packages either
+// hold the types it returns or hold logic that is meant to be upstreamed to kube-scheduler
+// (see the note on package layout below).
+//
+// # Getting started
+//
+// The setup is done once per consumer:
+//
+//		client, err := simulator.NewReadonlyClient(restConfig)
+//		sim, err := simulator.NewSchedulingSimulator(ctx, cfg, client, nil)
+//
+//	  - simulator.NewReadonlyClient turns a *rest.Config into the only client type the library
+//	    accepts. Its transport rejects every mutating request, so a simulation cannot touch the
+//	    real cluster.
+//	  - simulator.NewSchedulingSimulator starts the informers and holds the configuration used to
+//	    build the scheduling profiles. cfg may be nil, which selects the default kube-scheduler
+//	    profile, and so may informerFactory, which makes the simulator create its own.
+//
+// # Obtaining a snapshot
+//
+// A snapshot.ClusterSnapshot is an in-memory, mutable view of the cluster that all the
+// simulation runs against. There are two ways to get one:
+//
+//   - SchedulingSimulator.NewClusterState followed by state.ClusterState.Snapshot, when the
+//     simulation should start from the live cluster state. ClusterState.Cache is fed from the
+//     consumer's informers/event handlers and Snapshot freezes it.
+//   - SchedulingSimulator.NewClusterSnapshot, when the simulation should start from an
+//     explicitly provided set of pods and nodes.
+//
+// Prefer these constructors over building a snapshot.ClusterSnapshot directly: they are the ones
+// that register the metrics and build the full plugin chain out of the KubeSchedulerConfiguration.
+//
+// # Simulating
+//
+// All the simulation methods live on *snapshot.ClusterSnapshot and are the methods a consumer is
+// expected to call:
+//
+//   - MakePlacement turns node names into the *fwk.Placement that the other methods restrict
+//     the simulation to.
+//   - CanSchedulePod reports which of the nodes in the placement fit a single pod, without
+//     changing the snapshot.
+//   - SchedulePods schedules the given pods one by one and, unless DryRun is set, keeps the
+//     result in the snapshot.
+//   - SchedulePodsByTemplate schedules as many pods created from a pod template as fit.
+//   - PreemptPods removes running pods from the snapshot, and Unpreempt puts them back.
+//   - Transaction groups any of the above and commits or reverts them as a whole.
+//
+// # Package layout
+//
+// The types returned by this package deliberately live elsewhere:
+//
+//   - pkg/state holds ClusterState, the long-lived, mutable representation of the real cluster.
+//   - pkg/upstreamsync holds logic copied from (or destined for) kube-scheduler; consumers are
+//     not expected to call into it directly. pkg/upstreamsync/snapshot holds ClusterSnapshot,
+//     which is intended to be absorbed by kube-scheduler's snapshot handling over time, which is
+//     why it lives under upstreamsync despite carrying the consumer-facing methods listed above.
+//   - pkg/framework wires the upstream scheduler framework for in-memory use.
+package simulator

--- a/pkg/simulator/readonly_client.go
+++ b/pkg/simulator/readonly_client.go
@@ -22,10 +22,25 @@ import (
 	"k8s.io/client-go/rest"
 )
 
+// ReadonlyClient is the only way for a library consumer to hand a Kubernetes client to
+// NewSchedulingSimulator. It wraps a kubernetes.Interface whose transport rejects every
+// mutating request, which guarantees that a simulation can never modify the real cluster.
+//
+// The library needs a client because the scheduler framework and several plugins take one
+// (directly or through the informers) to read the cluster state. Since the wrapped client is
+// unexported and can only be produced by NewReadonlyClient from a *rest.Config, consumers
+// cannot substitute a client that writes.
+//
+// The transport-level rejection is a safety net rather than a functional requirement: with a
+// correct implementation no mutating request is ever issued (see the no-op event recorder and
+// APICacher in pkg/framework). Tests, which live inside the library, construct ReadonlyClient
+// directly with a fake client instead of going through NewReadonlyClient.
 type ReadonlyClient struct {
 	client kubernetes.Interface
 }
 
+// NewReadonlyClient builds a ReadonlyClient from the given rest config. The config is copied,
+// so the caller's config is left untouched.
 func NewReadonlyClient(config *rest.Config) (ReadonlyClient, error) {
 	if config == nil {
 		return ReadonlyClient{}, fmt.Errorf("got nil config")
@@ -36,10 +51,13 @@ func NewReadonlyClient(config *rest.Config) (ReadonlyClient, error) {
 	return ReadonlyClient{client: client}, err
 }
 
+// readonlyRoundTripper fails any request that could mutate the cluster before it leaves the process.
 type readonlyRoundTripper struct {
 	rt http.RoundTripper
 }
 
+// RoundTrip rejects the HTTP methods used by the create, update, patch and delete verbs,
+// and passes everything else (get, list, watch) to the wrapped transport.
 func (c *readonlyRoundTripper) RoundTrip(req *http.Request) (*http.Response, error) {
 	switch req.Method {
 	case http.MethodPost, http.MethodPut, http.MethodPatch, http.MethodDelete:
@@ -48,6 +66,7 @@ func (c *readonlyRoundTripper) RoundTrip(req *http.Request) (*http.Response, err
 	return c.rt.RoundTrip(req)
 }
 
+// readonlyRoundTripperFactory adapts readonlyRoundTripper to rest.Config.Wrap.
 func readonlyRoundTripperFactory(rt http.RoundTripper) http.RoundTripper {
 	return &readonlyRoundTripper{rt: rt}
 }

--- a/pkg/simulator/simulator.go
+++ b/pkg/simulator/simulator.go
@@ -27,10 +27,53 @@ import (
 
 	"k8s.io/client-go/informers"
 	"k8s.io/client-go/kubernetes"
+	fwk "k8s.io/kube-scheduler/framework"
 	"k8s.io/kubernetes/pkg/scheduler"
 	schedulerapi "k8s.io/kubernetes/pkg/scheduler/apis/config"
 	"k8s.io/kubernetes/pkg/scheduler/backend/cache"
+	schedFwk "k8s.io/kubernetes/pkg/scheduler/framework"
 )
+
+// Simulator is the set of "what-if" operations that run against a single in-memory view of the
+// cluster. It is implemented by *snapshot.ClusterSnapshot — what SchedulingSimulator.NewClusterSnapshot
+// returns and what state.ClusterState.Snapshot hands out — and exists to make the entry points of a
+// simulation visible from this package; consumers are not expected to implement it.
+type Simulator interface {
+	// MakePlacement turns node names into the *fwk.Placement that the other methods restrict the simulation to.
+	MakePlacement(candidateNodeNames []string) (*fwk.Placement, error)
+
+	// CanSchedulePod reports which of the nodes in the placement fit a single pod, leaving the
+	// snapshot untouched. The returned *schedFwk.Diagnosis explains why the remaining nodes were
+	// rejected.
+	CanSchedulePod(ctx context.Context, pod *v1.Pod, placement *fwk.Placement) ([]string, *schedFwk.Diagnosis, error)
+
+	// SchedulePods schedules the given pods one by one onto the placement and, unless opts.DryRun is
+	// set, keeps the result in the snapshot; every scheduled pod gets its Spec.NodeName set. The
+	// returned slice holds one result per attempted pod.
+	SchedulePods(ctx context.Context, pods []*v1.Pod, placement *fwk.Placement, opts snapshot.SchedulePodsOptions) ([]snapshot.SchedulingResult, error)
+
+	// SchedulePodsByTemplate schedules as many pods created from the template as fit, up to maxPods.
+	// It stops at the first pod that does not fit, as the next identical one would not fit either;
+	// each SchedulingResult carries the generated pod, which is the only way to learn what was
+	// scheduled.
+	SchedulePodsByTemplate(ctx context.Context, template *v1.PodTemplateSpec, placement *fwk.Placement, maxPods int, opts snapshot.SchedulePodsByTemplateOptions) ([]snapshot.SchedulingResult, error)
+
+	// PreemptPods removes the given running pods from the snapshot and returns the handle that puts
+	// them back. The handle is single-use and is invalidated by any later permanent mutation of the
+	// snapshot. If any pod fails to be preempted, the ones already removed by this call are restored
+	// and an error is returned.
+	PreemptPods(ctx context.Context, pods []*v1.Pod) (_ *snapshot.Unpreemption, err error)
+
+	// Transaction groups any of the above and commits or reverts them as a whole: the mutations are
+	// kept if transactionFn returns snapshot.Commit, and undone if it returns snapshot.Revert or an
+	// error. Transactions cannot be nested.
+	Transaction(ctx context.Context, transactionFn func() (snapshot.TransactionResult, error)) error
+
+	// Unpreempt undoes the preemption the handle was returned for and reports the pods that were put
+	// back. It fails if the handle has already been used, or if the snapshot has moved on since the
+	// preemption.
+	Unpreempt(u *snapshot.Unpreemption) ([]*v1.Pod, error)
+}
 
 // SchedulingSimulator is the entry point of the library: it owns the scheduler configuration and
 // the informers, and creates the objects the simulation is run against (see NewClusterState and
@@ -90,7 +133,7 @@ func (s *SchedulingSimulator) NewClusterState(ctx context.Context) (*state.Clust
 }
 
 // NewClusterSnapshot initializes a new snapshot with the provided pods and nodes.
-func (s *SchedulingSimulator) NewClusterSnapshot(ctx context.Context, pods []*v1.Pod, nodes []*v1.Node) (*snapshot.ClusterSnapshot, error) {
+func (s *SchedulingSimulator) NewClusterSnapshot(ctx context.Context, pods []*v1.Pod, nodes []*v1.Node) (Simulator, error) {
 	snap := cache.NewSnapshot(pods, nodes)
 
 	profiles, err := s.buildProfileMap(ctx, snap)

--- a/pkg/simulator/simulator.go
+++ b/pkg/simulator/simulator.go
@@ -32,6 +32,10 @@ import (
 	"k8s.io/kubernetes/pkg/scheduler/backend/cache"
 )
 
+// SchedulingSimulator is the entry point of the library: it owns the scheduler configuration and
+// the informers, and creates the objects the simulation is run against (see NewClusterState and
+// NewClusterSnapshot). It is meant to be created once and reused; every state and snapshot it
+// creates gets its own scheduling profiles built from the same configuration.
 type SchedulingSimulator struct {
 	cfg             *schedulerapi.KubeSchedulerConfiguration
 	informerFactory informers.SharedInformerFactory
@@ -39,6 +43,9 @@ type SchedulingSimulator struct {
 }
 
 // NewSchedulingSimulator creates a new SchedulingSimulator.
+// The cfg may be nil, in which case the default kube-scheduler profile is used, and so may the
+// informerFactory, in which case one is created from the client. The informers are started and
+// synced before returning, so the call blocks until the cluster state has been read.
 func NewSchedulingSimulator(
 	ctx context.Context,
 	cfg *schedulerapi.KubeSchedulerConfiguration,

--- a/pkg/state/state_test.go
+++ b/pkg/state/state_test.go
@@ -18,6 +18,7 @@ import (
 	"testing"
 
 	v1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/util/sets"
 	"k8s.io/client-go/informers"
 	"k8s.io/client-go/kubernetes/fake"
 	"k8s.io/klog/v2"
@@ -41,18 +42,18 @@ func TestClusterState_AddPod(t *testing.T) {
 		name         string
 		existingPods []*v1.Pod
 		podToAdd     *v1.Pod
-		wantErr  bool
-		expected map[string][]string
+		wantErr      bool
+		expected     map[string]sets.Set[string]
 	}{
 		{
 			name:     "add unassigned pod",
 			podToAdd: st.MakePod().Name("pod1").Namespace("default").UID("uid-pod1").Obj(),
-			expected: map[string][]string{"node1": {}},
+			expected: map[string]sets.Set[string]{"node1": sets.New[string]()},
 		},
 		{
 			name:     "add assigned pod",
 			podToAdd: st.MakePod().Name("pod1").Namespace("default").UID("uid-pod1").Node("node1").Obj(),
-			expected: map[string][]string{"node1": {"pod1"}},
+			expected: map[string]sets.Set[string]{"node1": sets.New("pod1")},
 		},
 		{
 			name: "add duplicate pod",
@@ -61,7 +62,7 @@ func TestClusterState_AddPod(t *testing.T) {
 			},
 			podToAdd: st.MakePod().Name("pod1").Namespace("default").UID("uid-pod1").Node("node1").Obj(),
 			wantErr:  true,
-			expected: map[string][]string{"node1": {"pod1"}},
+			expected: map[string]sets.Set[string]{"node1": sets.New("pod1")},
 		},
 	}
 
@@ -104,8 +105,8 @@ func TestClusterState_RemovePod(t *testing.T) {
 		name         string
 		existingPods []*v1.Pod
 		podToRemove  *v1.Pod
-		wantErr     bool
-		expected    map[string][]string
+		wantErr      bool
+		expected     map[string]sets.Set[string]
 	}{
 		{
 			name: "remove existing pod",
@@ -113,7 +114,7 @@ func TestClusterState_RemovePod(t *testing.T) {
 				st.MakePod().Name("pod1").Namespace("default").UID("uid-pod1").Node("node1").Obj(),
 			},
 			podToRemove: st.MakePod().Name("pod1").Namespace("default").UID("uid-pod1").Node("node1").Obj(),
-			expected:    map[string][]string{"node1": {}},
+			expected:    map[string]sets.Set[string]{"node1": sets.New[string]()},
 		},
 		{
 			name: "remove non-existent pod",
@@ -122,7 +123,7 @@ func TestClusterState_RemovePod(t *testing.T) {
 			},
 			podToRemove: st.MakePod().Name("pod2").Namespace("default").UID("uid-pod2").Node("node1").Obj(),
 			wantErr:     true,
-			expected:    map[string][]string{"node1": {"pod1"}},
+			expected:    map[string]sets.Set[string]{"node1": sets.New("pod1")},
 		},
 	}
 
@@ -165,7 +166,7 @@ func TestClusterState_AddNode(t *testing.T) {
 		name          string
 		existingNodes []*v1.Node
 		nodeToAdd     *v1.Node
-		expected      map[string][]string
+		expected      map[string]sets.Set[string]
 	}{
 		{
 			name: "add valid node",
@@ -174,7 +175,7 @@ func TestClusterState_AddNode(t *testing.T) {
 				v1.ResourceMemory: "1Gi",
 				v1.ResourcePods:   "110",
 			}).Obj(),
-			expected: map[string][]string{"node1": {}},
+			expected: map[string]sets.Set[string]{"node1": sets.New[string]()},
 		},
 		{
 			name: "add duplicate node",
@@ -190,7 +191,7 @@ func TestClusterState_AddNode(t *testing.T) {
 				v1.ResourceMemory: "1Gi",
 				v1.ResourcePods:   "110",
 			}).Obj(),
-			expected: map[string][]string{"node1": {}},
+			expected: map[string]sets.Set[string]{"node1": sets.New[string]()},
 		},
 	}
 
@@ -227,7 +228,7 @@ func TestClusterState_RemoveNode(t *testing.T) {
 		existingNodes []*v1.Node
 		nodeToRemove  *v1.Node
 		wantErr       bool
-		expected      map[string][]string
+		expected      map[string]sets.Set[string]
 	}{
 		{
 			name: "remove existing node",
@@ -235,7 +236,7 @@ func TestClusterState_RemoveNode(t *testing.T) {
 				st.MakeNode().Name("node1").Obj(),
 			},
 			nodeToRemove: st.MakeNode().Name("node1").Obj(),
-			expected:     map[string][]string{},
+			expected:     map[string]sets.Set[string]{},
 		},
 		{
 			name: "remove non-existent node",
@@ -244,7 +245,7 @@ func TestClusterState_RemoveNode(t *testing.T) {
 			},
 			nodeToRemove: st.MakeNode().Name("node2").Obj(),
 			wantErr:      true,
-			expected:     map[string][]string{"node1": {}},
+			expected:     map[string]sets.Set[string]{"node1": sets.New[string]()},
 		},
 	}
 
@@ -283,12 +284,12 @@ func TestClusterState_Snapshot(t *testing.T) {
 		name          string
 		existingNodes []*v1.Node
 		existingPods  []*v1.Pod
-		hasFramework bool
-		expected     map[string][]string
+		hasFramework  bool
+		expected      map[string]sets.Set[string]
 	}{
 		{
 			name:     "empty snapshot",
-			expected: map[string][]string{},
+			expected: map[string]sets.Set[string]{},
 		},
 		{
 			name: "snapshot with data",
@@ -298,7 +299,7 @@ func TestClusterState_Snapshot(t *testing.T) {
 			existingPods: []*v1.Pod{
 				st.MakePod().Name("pod1").Namespace("default").UID("uid-pod1").Node("node1").Obj(),
 			},
-			expected: map[string][]string{"node1": {"pod1"}},
+			expected: map[string]sets.Set[string]{"node1": sets.New("pod1")},
 		},
 		{
 			name: "snapshot in sync with framework snapshot",
@@ -309,7 +310,7 @@ func TestClusterState_Snapshot(t *testing.T) {
 				st.MakePod().Name("pod1").Namespace("default").UID("uid-pod1").Node("node1").Obj(),
 			},
 			hasFramework: true,
-			expected:     map[string][]string{"node1": {"pod1"}},
+			expected:     map[string]sets.Set[string]{"node1": sets.New("pod1")},
 		},
 	}
 
@@ -415,7 +416,7 @@ func TestClusterState_SequentialUpdates(t *testing.T) {
 		}
 	}
 
-	assertSnapshot := func(expected map[string][]string) action {
+	assertSnapshot := func(expected map[string]sets.Set[string]) action {
 		return func(t *testing.T, state *ClusterState) {
 			t.Helper()
 			ft.VerifySnapshot(t, state.sharedSnap, expected)
@@ -438,10 +439,10 @@ func TestClusterState_SequentialUpdates(t *testing.T) {
 			steps: []action{
 				addPod(pod1),
 				updateSnapshot(),
-				assertSnapshot(map[string][]string{}),
+				assertSnapshot(map[string]sets.Set[string]{}),
 				addNode(node1),
 				updateSnapshot(),
-				assertSnapshot(map[string][]string{"node1": {"pod1"}}),
+				assertSnapshot(map[string]sets.Set[string]{"node1": sets.New("pod1")}),
 			},
 		},
 		{
@@ -450,13 +451,13 @@ func TestClusterState_SequentialUpdates(t *testing.T) {
 				addNode(node1),
 				addPod(pod1),
 				updateSnapshot(),
-				assertSnapshot(map[string][]string{"node1": {"pod1"}}),
+				assertSnapshot(map[string]sets.Set[string]{"node1": sets.New("pod1")}),
 				removeNode(node1),
 				updateSnapshot(),
-				assertSnapshot(map[string][]string{}),
+				assertSnapshot(map[string]sets.Set[string]{}),
 				removePod(pod1),
 				updateSnapshot(),
-				assertSnapshot(map[string][]string{}),
+				assertSnapshot(map[string]sets.Set[string]{}),
 			},
 		},
 	}

--- a/pkg/upstreamsync/doc.go
+++ b/pkg/upstreamsync/doc.go
@@ -1,0 +1,34 @@
+// Copyright The Kubernetes Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package upstreamsync holds the logic that is duplicated from, or destined for, the upstream
+// kube-scheduler. It is not the library's entry point: consumers should start from
+// sigs.k8s.io/scheduler-library/pkg/simulator.
+//
+// Everything here is temporary debt, kept in one place so that it is easy to see what has to be
+// merged back into kubernetes/kubernetes, as described in CONTRIBUTING.md.
+//
+// # Marking the divergences from upstream
+//
+// Code copied from kube-scheduler keeps the upstream doc comments verbatim, so that a copy can be
+// diffed against its origin. Every intentional deviation is called out with a comment starting
+// with the "UPSTREAM-DIFF:" prefix, placed either on the declaration (when the whole function
+// differs) or right at the line that differs. Grepping for the prefix lists everything that has to
+// be reconciled before the code can be upstreamed:
+//
+//	grep -rn "UPSTREAM-DIFF:" pkg/
+//
+// Each such comment states what changed and why, e.g. that the library has no scheduling queue,
+// so the nomination handling was dropped.
+package upstreamsync

--- a/pkg/upstreamsync/framework.go
+++ b/pkg/upstreamsync/framework.go
@@ -55,7 +55,10 @@ Common initialization logic would prevent accidental divergence between the libr
 The library would need to ensure the provided clientset intercepts and prevents resource mutations.
 
 
-Extracted from kubernetes/kubernetes/pkg/upstreamsync/scheduler/scheduler.go
+Extracted from kubernetes/kubernetes/pkg/scheduler/scheduler.go
+
+Deviations from the upstream scheduler.New are marked with the "UPSTREAM-DIFF:" prefix,
+see pkg/upstreamsync/doc.go.
 
 */
 
@@ -72,10 +75,21 @@ type frameworkOptions struct {
 
 type Option = func(*frameworkOptions)
 
+// ProfileMap holds one framework.Framework per scheduler name.
+//
+// UPSTREAM-DIFF: library-only. Upstream keeps the profile.Map inside the Scheduler and resolves the
+// framework in Scheduler.frameworkForPod; the library has no Scheduler holding long-lived state,
+// so the map is passed around explicitly.
 type ProfileMap struct {
 	profile.Map
 }
 
+// FrameworkForPod returns the framework of the profile the pod asked for, defaulting to the
+// default scheduler name when the pod does not name one.
+//
+// UPSTREAM-DIFF: adapted from Scheduler.frameworkForPod in schedule_one.go, which looks the profile
+// up by pod.Spec.SchedulerName as-is. Pods admitted by the API server always have that field
+// defaulted, while simulated pods may not, so an empty name is mapped to the default profile here.
 func (p *ProfileMap) FrameworkForPod(pod *v1.Pod) (framework.Framework, error) {
 	schedulerName := pod.Spec.SchedulerName
 	// This won't happen if we're dealing with real pods, but may happen when running simulations
@@ -96,6 +110,14 @@ func WithProfiles(p ...schedulerapi.KubeSchedulerProfile) Option {
 	}
 }
 
+// NewProfileMap builds the scheduling profiles out of the given configuration and dependencies.
+//
+// UPSTREAM-DIFF: extracted from scheduler.New, keeping only the framework construction. Everything
+// that a running scheduler needs and a simulation does not — the scheduling queue, the event
+// handlers, the cache and its debugger, the binding machinery — is dropped. The snapshot, the
+// nominator, the activator and the API cacher are supplied by the caller instead of being created
+// here, so that the caller can share the snapshot with the frameworks and neutralize the extension
+// points that would otherwise reach the API server (see pkg/framework).
 func NewProfileMap(ctx context.Context,
 	client clientset.Interface,
 	informerFactory informers.SharedInformerFactory,

--- a/pkg/upstreamsync/mutable_snapshot.go
+++ b/pkg/upstreamsync/mutable_snapshot.go
@@ -35,8 +35,14 @@ We will want to expose AddPod/RemovePod for pods that were originally in the sna
 
 Both cases can be unified under the same Add/Remove operations.
 
+UPSTREAM-DIFF: the whole file is library-only. It has no counterpart in kube-scheduler yet; it
+lives here because it is proposed for the upstream snapshot, not because it was copied from it.
+
 */
 
+// MutatingSnapshot wraps a cache.Snapshot with Add/RemovePod operations that keep track of what
+// was changed, so that the snapshot can be restored to the state it had when the wrapper was
+// created (see RestoreState).
 type MutatingSnapshot struct {
 	*cache.Snapshot
 	addedPods   map[string]func()

--- a/pkg/upstreamsync/scheduler.go
+++ b/pkg/upstreamsync/scheduler.go
@@ -50,12 +50,24 @@ This component would be used in PG scheduling cycle, pod-by-pod scheduling cycle
 In PG scheduling cycle, the caller would additionally run the placement feasible extensions etc.
 In pod-by-pod scheduling cycle, the caller would additionally run post filter extensions.
 
-Extracted from kubernetes/kubernetes/pkg/upstreamsync/scheduler/schedule_one.go and schedule_one_podgroup.go
+Extracted from kubernetes/kubernetes/pkg/scheduler/schedule_one.go and schedule_one_podgroup.go
+
+The upstream doc comments are kept verbatim so that each copy can be diffed against its origin.
+Every intentional deviation is marked with the "UPSTREAM-DIFF:" prefix, either on the declaration
+or on the exact line that differs. See pkg/upstreamsync/doc.go and CONTRIBUTING.md.
 
 */
 
 type ScheduleResult = scheduler.ScheduleResult
 
+// Scheduler holds the state a single scheduling attempt needs.
+//
+// UPSTREAM-DIFF: replaces scheduler.Scheduler, keeping only the fields the scheduling algorithm
+// reads. The library has no scheduler cache (the snapshot is mutated directly), no scheduling
+// queue and no scheduler-level extenders (they are taken from the framework), so those fields are
+// absent. currentCycle, nextStartNodeIndex and numNodesToFind are supplied by the caller instead of
+// being owned and advanced by a long-running scheduler, because each simulation drives its own
+// sequence of scheduling cycles.
 type Scheduler struct {
 	nodeInfoSnapshot   *cache.Snapshot
 	currentCycle       int64
@@ -63,6 +75,13 @@ type Scheduler struct {
 	numNodesToFind     int32
 }
 
+// NewScheduler creates a Scheduler operating on the given snapshot.
+// numNodesToFind caps how many feasible nodes a scheduling attempt looks for; pass math.MaxInt32
+// to consider all of them.
+//
+// UPSTREAM-DIFF: upstream derives numNodesToFind per attempt from PercentageOfNodesToScore
+// (see Scheduler.numFeasibleNodesToFind), which is not copied here. Simulations need a
+// deterministic, caller-controlled bound instead of a sampling heuristic.
 func NewScheduler(nodeInfoSnapshot *cache.Snapshot,
 	currentCycle int64,
 	nextStartNodeIndex int,
@@ -75,12 +94,22 @@ func NewScheduler(nodeInfoSnapshot *cache.Snapshot,
 	}
 }
 
+// PendingPod is the pod being scheduled together with the state of its scheduling cycle.
+//
+// UPSTREAM-DIFF: replaces framework.QueuedPodInfo, which additionally carries queueing metadata
+// (attempt counters, timestamps, unschedulable plugins) that only a scheduling queue produces.
+// The CycleState is carried here instead of being passed as a separate argument, as upstream does.
 type PendingPod struct {
 	*framework.PodInfo
 	PodSignature fwk.PodSignature
 	CycleState   fwk.CycleState
 }
 
+// AlgorithmResult is the outcome of a single pod scheduling attempt.
+//
+// UPSTREAM-DIFF: replaces the unexported algorithmResult from schedule_one_podgroup.go. The
+// scheduling duration, the pod scheduling context and the permit status are dropped: the library
+// records no scheduling metrics and runs no Permit plugins (see SchedulePod).
 type AlgorithmResult struct {
 	ScheduleResult ScheduleResult
 	Pod            *v1.Pod
@@ -88,6 +117,19 @@ type AlgorithmResult struct {
 	CycleState     fwk.CycleState
 }
 
+// SchedulePod runs a scheduling algorithm for individual pod from a pod group.
+// It returns the algorithm result and, if successful or the preemption is required, the permit status together with the revert function.
+//
+// UPSTREAM-DIFF: adapted from Scheduler.podGroupPodSchedulingAlgorithm. Differences:
+//   - no pod group: the caller supplies the CycleState in the PendingPod instead of it being
+//     derived from the pod group cycle state, and there is no podSchedulingContext.
+//   - schedulePod is called directly rather than through schedulingAlgorithm, so no PostFilter
+//     plugins run and no nomination happens. Preemption is not an implicit part of a scheduling
+//     attempt in the library; it is requested explicitly via ClusterSnapshot.PreemptPods.
+//     The upstream errors are mapped to a Status here, which schedulingAlgorithm does upstream.
+//   - Permit plugins are not run, since nothing waits on them in an in-memory simulation.
+//   - no scheduling duration or nominatingInfo in the result, as the library records no
+//     scheduling metrics and has no scheduling queue to nominate to.
 func (sched *Scheduler) SchedulePod(ctx context.Context, schedFwk framework.Framework, podInfo *PendingPod) (AlgorithmResult, func()) {
 	pod := podInfo.Pod
 	state := podInfo.CycleState
@@ -133,6 +175,9 @@ func (sched *Scheduler) SchedulePod(ctx context.Context, schedFwk framework.Fram
 }
 
 // assumeAndReserve assumes and reserves the pod in scheduler's memory.
+//
+// UPSTREAM-DIFF: identical to Scheduler.assumeAndReserve, except that it takes and returns
+// *framework.PodInfo instead of *framework.QueuedPodInfo (see PendingPod).
 func (sched *Scheduler) assumeAndReserve(
 	ctx context.Context,
 	state fwk.CycleState,
@@ -184,6 +229,11 @@ func (sched *Scheduler) assumeAndReserve(
 // unreserveAndForget unreserves and forgets the pod from scheduler's memory.
 // This function shouldn't be called during binding cycle with a state, where IsPodGroupSchedulingCycle is set to true,
 // but this shouldn't happen, because such pods with such state cannot reach binding.
+//
+// UPSTREAM-DIFF: upstream branches on state.IsPodGroupSchedulingCycle() and forgets the pod either
+// from the snapshot or from the scheduler cache. The library always forgets from the snapshot,
+// because it has no scheduler cache to bind through. Restoring the pod's nomination is dropped
+// as well, since there is no scheduling queue holding nominated pods.
 func (sched *Scheduler) unreserveAndForget(
 	ctx context.Context,
 	state fwk.CycleState,
@@ -199,6 +249,10 @@ func (sched *Scheduler) unreserveAndForget(
 
 // assume signals to the cache that a pod is already in the cache, so that binding can be asynchronous.
 // When called during pod group scheduling cycle, pod is assumed in the snapshot instead.
+//
+// UPSTREAM-DIFF: the library always takes the pod group branch and assumes into the snapshot,
+// since nothing here ever binds a pod through the scheduler cache. Removing the pod from the
+// nominator is dropped, as there is no scheduling queue.
 func (sched *Scheduler) assume(logger klog.Logger, state fwk.CycleState, assumedPodInfo *framework.PodInfo, host string) error {
 	// Optimistically assume that the binding will succeed and send it to apiserver
 	// in the background.
@@ -227,6 +281,10 @@ func (sched *Scheduler) assume(logger klog.Logger, state fwk.CycleState, assumed
 // schedulePod tries to schedule the given pod to one of the nodes in the node list.
 // If it succeeds, it will return the name of the node.
 // If it fails, it will return a FitError with reasons.
+//
+// UPSTREAM-DIFF: the CycleState comes from podInfo instead of a separate argument, the extenders
+// come from the framework instead of sched.Extenders, and the current cycle is the currentCycle
+// field instead of Scheduler.CurrentCycle(). The body is otherwise unchanged.
 func (sched *Scheduler) schedulePod(ctx context.Context, fwk framework.Framework, podInfo *PendingPod) (result ScheduleResult, err error) {
 	pod := podInfo.Pod
 	trace := utiltrace.New("Scheduling", utiltrace.Field{Key: "namespace", Value: pod.Namespace}, utiltrace.Field{Key: "name", Value: pod.Name})
@@ -283,12 +341,23 @@ func (sched *Scheduler) schedulePod(ctx context.Context, fwk framework.Framework
 	}, err
 }
 
+// FindAllNodesThatFitPod returns every node in the placement that fits the pod, together with the
+// diagnosis explaining why the remaining ones were rejected.
+//
+// UPSTREAM-DIFF: library-only. Upstream never needs the complete set of feasible nodes, as it
+// stops as soon as it has enough candidates to score. Feasibility checks (see
+// ClusterSnapshot.CanSchedulePod) do need it.
 func (sched *Scheduler) FindAllNodesThatFitPod(ctx context.Context, schedFramework framework.Framework, podInfo *PendingPod) ([]fwk.NodeInfo, framework.Diagnosis, string, error) {
 	return sched.findNodesThatFitPod(ctx, schedFramework, podInfo, true)
 }
 
 // Filters the nodes to find the ones that fit the pod based on the framework
 // filter plugins and filter extenders.
+//
+// UPSTREAM-DIFF: takes the additional findAll flag (see FindAllNodesThatFitPod). When it is set,
+// the nominated node shortcut is skipped, because returning early with the nominated node alone
+// would hide the other feasible nodes the caller asked for. The CycleState comes from podInfo and
+// the extenders come from the framework instead of sched.Extenders.
 func (sched *Scheduler) findNodesThatFitPod(ctx context.Context, schedFramework framework.Framework, podInfo *PendingPod, findAll bool) ([]fwk.NodeInfo, framework.Diagnosis, string, error) {
 	state := podInfo.CycleState
 	logger := klog.FromContext(ctx)
@@ -328,6 +397,7 @@ func (sched *Scheduler) findNodesThatFitPod(ctx context.Context, schedFramework 
 	// "NominatedNodeName" can potentially be set in a previous scheduling cycle as a result of preemption.
 	// This node is likely the only candidate that will fit the pod, and hence we try it first before iterating over all nodes.
 	// We take the same tack for hinted nodes from the batch module.
+	// UPSTREAM-DIFF: guarded with !findAll, as the shortcut would hide the other feasible nodes.
 	if !findAll && (len(pod.Status.NominatedNodeName) > 0 || len(nodeHint) > 0) {
 		feasibleNodes, err := sched.evaluateNominatedNode(ctx, pod, schedFramework, state, nodeHint, diagnosis)
 		if err != nil {
@@ -382,6 +452,11 @@ func (sched *Scheduler) findNodesThatFitPod(ctx context.Context, schedFramework 
 	return feasibleNodesAfterExtender, diagnosis, nodeHint, nil
 }
 
+// evaluateNominatedNode checks whether the pod fits the node it was nominated to (or hinted at).
+//
+// UPSTREAM-DIFF: identical to Scheduler.evaluateNominatedNode, except that the extenders come from
+// the framework and findNodesThatPassFilters is called with findAll=false, which does not matter
+// as there is only one node to check anyway.
 func (sched *Scheduler) evaluateNominatedNode(ctx context.Context, pod *v1.Pod, schedFramework framework.Framework, state fwk.CycleState, nodeHint string, diagnosis framework.Diagnosis) ([]fwk.NodeInfo, error) {
 	// In the future we could potentially use the hint if the nominated node failed.
 	// https://github.com/kubernetes/kubernetes/issues/135163
@@ -416,6 +491,9 @@ func (sched *Scheduler) evaluateNominatedNode(ctx context.Context, pod *v1.Pod, 
 }
 
 // hasScoring checks if scoring nodes is configured.
+//
+// UPSTREAM-DIFF: a plain function taking the framework, instead of a Scheduler method, because the
+// extenders are read from the framework rather than from sched.Extenders.
 func hasScoring(fwk framework.Framework) bool {
 	if fwk.HasScorePlugins() {
 		return true
@@ -429,6 +507,9 @@ func hasScoring(fwk framework.Framework) bool {
 }
 
 // hasExtenderFilters checks if any extenders filter nodes.
+//
+// UPSTREAM-DIFF: a plain function taking the framework, instead of a Scheduler method, because the
+// extenders are read from the framework rather than from sched.Extenders.
 func hasExtenderFilters(fwk framework.Framework) bool {
 	for _, extender := range fwk.Extenders() {
 		if extender.IsFilter() {
@@ -439,6 +520,11 @@ func hasExtenderFilters(fwk framework.Framework) bool {
 }
 
 // findNodesThatPassFilters finds the nodes that fit the filter plugins.
+//
+// UPSTREAM-DIFF: takes the additional findAll flag, which makes it evaluate every node instead of
+// stopping early. Upstream computes the bound from PercentageOfNodesToScore via
+// Scheduler.numFeasibleNodesToFind; the library uses the caller-provided sched.numNodesToFind
+// (see NewScheduler). The body below is otherwise unchanged.
 func (sched *Scheduler) findNodesThatPassFilters(
 	ctx context.Context,
 	schedFramework framework.Framework,
@@ -448,6 +534,9 @@ func (sched *Scheduler) findNodesThatPassFilters(
 	nodes []fwk.NodeInfo,
 	findAll bool) ([]fwk.NodeInfo, error) {
 	numAllNodes := len(nodes)
+	// UPSTREAM-DIFF: upstream always samples via sched.numFeasibleNodesToFind(
+	// schedFramework.PercentageOfNodesToScore(), int32(numAllNodes)). Here the bound is either all
+	// the nodes (findAll) or the one the caller passed to NewScheduler.
 	numNodesToFind := int32(numAllNodes)
 	if !findAll {
 		numNodesToFind = sched.numNodesToFind
@@ -528,6 +617,9 @@ func (sched *Scheduler) findNodesThatPassFilters(
 	return feasibleNodes, nil
 }
 
+// findNodesThatPassExtenders runs the filter extenders over the nodes that passed the filter plugins.
+//
+// UPSTREAM-DIFF: none, copied verbatim.
 func findNodesThatPassExtenders(ctx context.Context, extenders []fwk.Extender, pod *v1.Pod, feasibleNodes []fwk.NodeInfo, statuses *framework.NodeToStatus) ([]fwk.NodeInfo, error) {
 	logger := klog.FromContext(ctx)
 
@@ -579,6 +671,8 @@ func findNodesThatPassExtenders(ctx context.Context, extenders []fwk.Extender, p
 // The scores from each plugin are added together to make the score for that node, then
 // any extenders are run as well.
 // All scores are finally combined (added) to get the total weighted scores of all nodes
+//
+// UPSTREAM-DIFF: none, copied verbatim.
 func prioritizeNodes(
 	ctx context.Context,
 	extenders []fwk.Extender,
@@ -657,6 +751,7 @@ func prioritizeNodes(
 
 					// MaxExtenderPriority may diverge from the max priority used in the scheduler and defined by MaxNodeScore,
 					// therefore we need to scale the score returned by extenders to the score range used by the scheduler.
+					// UPSTREAM-DIFF: uses fwk.MaxScore, while upstream still uses the deprecated fwk.MaxNodeScore alias.
 					finalscore := score * weight * (fwk.MaxScore / extenderv1.MaxExtenderPriority)
 
 					if allNodeExtendersScores[nodename] == nil {
@@ -692,6 +787,10 @@ func prioritizeNodes(
 	return nodesScores, nil
 }
 
+// sortedNodeScores pops the scored nodes in a decreasing score order.
+//
+// UPSTREAM-DIFF: none, copied verbatim, minus the PopScore method that upstream only uses in its
+// own unit tests.
 type sortedNodeScores struct {
 	nodes nodeScoreHeap
 }

--- a/pkg/upstreamsync/snapshot/doc.go
+++ b/pkg/upstreamsync/snapshot/doc.go
@@ -1,0 +1,27 @@
+// Copyright The Kubernetes Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package snapshot provides ClusterSnapshot, the in-memory, mutable view of the cluster that all
+// the simulation runs against.
+//
+// Although the package sits under upstreamsync — ClusterSnapshot is expected to be absorbed by
+// kube-scheduler's snapshot handling over time — its methods are the library's simulation API:
+// ClusterSnapshot.MakePlacement, CanSchedulePod, SchedulePods, SchedulePodsByTemplate,
+// PreemptPods, Unpreempt and Transaction.
+//
+// A ClusterSnapshot should be obtained from simulator.SchedulingSimulator, either via
+// NewClusterSnapshot or via NewClusterState followed by state.ClusterState.Snapshot. Calling New
+// directly requires the caller to build the scheduling profiles and initialize the scheduler
+// metrics themselves. See package sigs.k8s.io/scheduler-library/pkg/simulator for the full flow.
+package snapshot

--- a/pkg/upstreamsync/snapshot/helpers.go
+++ b/pkg/upstreamsync/snapshot/helpers.go
@@ -96,6 +96,9 @@ func createPodFromTemplate(template *v1.PodTemplateSpec, index int) *v1.Pod {
 }
 
 // scheduleOnePod simulates a single scheduling cycle for a pod against the assumed placement.
+// On success it returns the revert function undoing the changes the cycle made to the snapshot;
+// on a scheduling failure the returned function is nil and the reason is carried by the result's
+// Status.
 func scheduleOnePod(ctx context.Context, profiles *upstreamsync.ProfileMap, sched *upstreamsync.Scheduler, pod *v1.Pod) (*upstreamsync.AlgorithmResult, func(), error) {
 	schedFramework, err := profiles.FrameworkForPod(pod)
 	if err != nil {

--- a/pkg/upstreamsync/snapshot/helpers.go
+++ b/pkg/upstreamsync/snapshot/helpers.go
@@ -29,20 +29,20 @@ import (
 
 // addPodToNode adds a new pod to the specific node and returns the corresponding revert function
 func addPodToNode(ctx context.Context, schedulerSnapshot *upstreamsync.MutatingSnapshot, pod *v1.Pod, nodeName string) (func(), error) {
+	logger := klog.FromContext(ctx)
 	clonedPod := pod.DeepCopy()
 	clonedPod.Spec.NodeName = nodeName
 	podInfo, err := framework.NewPodInfo(clonedPod)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create pod info: %w", err)
 	}
-	err = schedulerSnapshot.AddPod(klog.FromContext(ctx), podInfo)
+	err = schedulerSnapshot.AddPod(logger, podInfo)
 	if err != nil {
 		return nil, fmt.Errorf("failed to add pod to snapshot: %w", err)
 	}
 
 	revertFn := func() {
 		if _, err := removePodFromNode(ctx, schedulerSnapshot, podInfo.Pod); err != nil {
-			logger := klog.FromContext(ctx)
 			logger.Error(err, "revert addPodToNode failed")
 		}
 	}
@@ -52,16 +52,16 @@ func addPodToNode(ctx context.Context, schedulerSnapshot *upstreamsync.MutatingS
 
 // removePodFromNode removes a pod from a specific node and returns the corresponding revert function.
 func removePodFromNode(ctx context.Context, schedulerSnapshot *upstreamsync.MutatingSnapshot, pod *v1.Pod) (func(), error) {
+	logger := klog.FromContext(ctx)
 	podInfo, err := framework.NewPodInfo(pod.DeepCopy())
 	if err != nil {
 		return nil, fmt.Errorf("failed to create pod info: %w", err)
 	}
-	err = schedulerSnapshot.RemovePod(klog.FromContext(ctx), podInfo)
+	err = schedulerSnapshot.RemovePod(logger, podInfo)
 	if err != nil {
 		return nil, fmt.Errorf("failed to remove pod from snapshot: %w", err)
 	}
 
-	logger := klog.FromContext(ctx)
 	revertFn := func() {
 		if _, err := addPodToNode(ctx, schedulerSnapshot, pod, pod.Spec.NodeName); err != nil {
 			logger.Error(err, "revert removePodFromNode failed")
@@ -98,7 +98,7 @@ func createPodFromTemplate(template *v1.PodTemplateSpec, index int) *v1.Pod {
 // scheduleOnePod simulates a single scheduling cycle for a pod against the assumed placement.
 // On success it returns the revert function undoing the changes the cycle made to the snapshot;
 // on a scheduling failure the returned function is nil and the reason is carried by the result's
-// Status.
+// Status. The pod is left untouched: it is up to the caller to reflect suggestedHost on it.
 func scheduleOnePod(ctx context.Context, profiles *upstreamsync.ProfileMap, sched *upstreamsync.Scheduler, pod *v1.Pod) (*upstreamsync.AlgorithmResult, func(), error) {
 	schedFramework, err := profiles.FrameworkForPod(pod)
 	if err != nil {
@@ -118,14 +118,9 @@ func scheduleOnePod(ctx context.Context, profiles *upstreamsync.ProfileMap, sche
 	}
 	algRes, revertFn := sched.SchedulePod(ctx, schedFramework, pendingPod)
 
-	if err != nil {
-		return nil, nil, fmt.Errorf("failed to simulate scheduling for pod %s: %w", klog.KObj(pod), err)
-	}
-
 	if !algRes.Status.IsSuccess() {
 		return &algRes, nil, nil
 	}
 
-	pod.Spec.NodeName = algRes.ScheduleResult.SuggestedHost
 	return &algRes, revertFn, nil
 }

--- a/pkg/upstreamsync/snapshot/helpers_test.go
+++ b/pkg/upstreamsync/snapshot/helpers_test.go
@@ -302,7 +302,7 @@ func TestScheduleOnePod(t *testing.T) {
 		name          string
 		nodes         []*v1.Node
 		pod           *v1.Pod
-		candidates    []string
+		candidate     string
 		expectSuccess bool
 		expectErr     bool
 	}{
@@ -316,7 +316,7 @@ func TestScheduleOnePod(t *testing.T) {
 				}).Obj(),
 			},
 			pod:           st.MakePod().Name("pod1").Namespace("default").UID("uid-pod1").SchedulerName(v1.DefaultSchedulerName).Req(map[v1.ResourceName]string{v1.ResourceCPU: "1"}).Obj(),
-			candidates:    []string{"node1"},
+			candidate:     "node1",
 			expectSuccess: true,
 			expectErr:     false,
 		},
@@ -330,7 +330,7 @@ func TestScheduleOnePod(t *testing.T) {
 				}).Obj(),
 			},
 			pod:           st.MakePod().Name("pod1").Namespace("default").UID("uid-pod1").SchedulerName(v1.DefaultSchedulerName).Req(map[v1.ResourceName]string{v1.ResourceCPU: "2"}).Obj(),
-			candidates:    []string{"node1"},
+			candidate:     "node1",
 			expectSuccess: false,
 			expectErr:     false,
 		},
@@ -338,7 +338,7 @@ func TestScheduleOnePod(t *testing.T) {
 			name:          "error - framework not found",
 			nodes:         []*v1.Node{st.MakeNode().Name("node1").Obj()},
 			pod:           st.MakePod().Name("pod1").Namespace("default").UID("uid-pod1").SchedulerName("non-existent-scheduler-profile").Obj(),
-			candidates:    []string{"node1"},
+			candidate:     "node1",
 			expectSuccess: false,
 			expectErr:     true,
 		},
@@ -348,7 +348,7 @@ func TestScheduleOnePod(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			cs, snap, _ := setupSnapshotTest(t, ctx, tc.nodes, nil)
 
-			placement, err := cs.MakePlacement(tc.candidates)
+			placement, err := cs.MakePlacement([]string{tc.candidate})
 			if err != nil {
 				t.Fatalf("MakePlacement failed: %v", err)
 			}
@@ -371,9 +371,14 @@ func TestScheduleOnePod(t *testing.T) {
 				t.Fatalf("expected scheduling success %v, got %v", tc.expectSuccess, algRes.Status.IsSuccess())
 			}
 
+			// scheduleOnePod leaves the pod untouched; reflecting the result on it is up to the caller.
+			if tc.pod.Spec.NodeName != "" {
+				t.Errorf("expected pod.Spec.NodeName to remain empty, got %q", tc.pod.Spec.NodeName)
+			}
+
 			if tc.expectSuccess {
-				if tc.pod.Spec.NodeName != tc.candidates[0] {
-					t.Errorf("expected pod.Spec.NodeName to be %q, got %q", tc.candidates[0], tc.pod.Spec.NodeName)
+				if algRes.ScheduleResult.SuggestedHost != tc.candidate {
+					t.Errorf("expected SuggestedHost to be %q, got %q", tc.candidate, algRes.ScheduleResult.SuggestedHost)
 				}
 				if revertFn == nil {
 					t.Fatal("expected revertFn to be non-nil")
@@ -382,7 +387,7 @@ func TestScheduleOnePod(t *testing.T) {
 				// Revert the scheduling
 				revertFn()
 
-				nodeInfo, err := snap.Get(tc.candidates[0])
+				nodeInfo, err := snap.Get(tc.candidate)
 				if err != nil {
 					t.Fatalf("unexpected error getting node: %v", err)
 				}
@@ -390,9 +395,6 @@ func TestScheduleOnePod(t *testing.T) {
 					t.Errorf("expected 0 pods on node after revert, got %d", len(nodeInfo.GetPods()))
 				}
 			} else {
-				if tc.pod.Spec.NodeName != "" {
-					t.Errorf("expected pod.Spec.NodeName to remain empty, got %q", tc.pod.Spec.NodeName)
-				}
 				if revertFn != nil {
 					t.Error("expected revertFn to be nil")
 				}

--- a/pkg/upstreamsync/snapshot/snapshot.go
+++ b/pkg/upstreamsync/snapshot/snapshot.go
@@ -16,6 +16,7 @@ package snapshot
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"iter"
 	"math"
@@ -267,6 +268,12 @@ func (s *ClusterSnapshot) schedulePods(ctx context.Context, pods iter.Seq[*v1.Po
 			return result, err
 		}
 
+		if res.Status.IsSuccess() {
+			// Reflect the simulated placement on the caller's pod, so that a pod scheduled in this
+			// loop is seen as assigned by whoever inspects it, including the SchedulingResult below.
+			pod.Spec.NodeName = res.ScheduleResult.SuggestedHost
+		}
+
 		if revertFn != nil {
 			s.undoLog.registerOperation(revertFn)
 		}
@@ -322,7 +329,7 @@ func (s *ClusterSnapshot) PreemptPods(ctx context.Context, pods []*v1.Pod) (_ *U
 
 	mutatingSnapshot := upstreamsync.NewMutatingSnapshot(s.schedulerSnapshot)
 
-	unpreemptFns := []func(){}
+	unpreemptFns := []func() error{}
 
 	for _, pod := range pods {
 		revertFn, err := removePodFromNode(ctx, mutatingSnapshot, pod)
@@ -330,18 +337,27 @@ func (s *ClusterSnapshot) PreemptPods(ctx context.Context, pods []*v1.Pod) (_ *U
 			return nil, fmt.Errorf("failed to unreserve and forget pod %s: %w", klog.KObj(pod), err)
 		}
 		s.undoLog.registerOperation(revertFn)
-		unpreemptFns = append(unpreemptFns, func() {
-			revertFn()
-			s.undoLog.registerOperation(func() {
-				_, _ = removePodFromNode(ctx, mutatingSnapshot, pod)
-			})
+		// Putting the pod back is a snapshot mutation like any other, so it goes through
+		// addPodToNode and registers its own revert function, undoing it re-preempts the pod.
+		unpreemptFns = append(unpreemptFns, func() error {
+			repreemptFn, err := addPodToNode(ctx, mutatingSnapshot, pod, pod.Spec.NodeName)
+			if err != nil {
+				return fmt.Errorf("failed to unpreempt pod %s: %w", klog.KObj(pod), err)
+			}
+			s.undoLog.registerOperation(repreemptFn)
+			return nil
 		})
 	}
 
-	unpreemptFn := func() {
-		for _, revertFn := range slices.Backward(unpreemptFns) {
-			revertFn()
+	unpreemptFn := func() error {
+		var errs []error
+		for _, unpreempt := range slices.Backward(unpreemptFns) {
+			// Keep going on failure, so that as many pods as possible are put back.
+			if err := unpreempt(); err != nil {
+				errs = append(errs, err)
+			}
 		}
+		return errors.Join(errs...)
 	}
 
 	return &Unpreemption{
@@ -352,6 +368,8 @@ func (s *ClusterSnapshot) PreemptPods(ctx context.Context, pods []*v1.Pod) (_ *U
 }
 
 // Unpreempt undos the preemption done by the PreemptPods.
+// The handle is consumed even if putting some of the pods back fails, in which case the pods that
+// were restored are still registered in the undo log and are rolled back with the transaction.
 func (s *ClusterSnapshot) Unpreempt(u *Unpreemption) ([]*v1.Pod, error) {
 	if u == nil {
 		return nil, fmt.Errorf("preemption handle is nil")
@@ -363,11 +381,15 @@ func (s *ClusterSnapshot) Unpreempt(u *Unpreemption) ([]*v1.Pod, error) {
 		return nil, fmt.Errorf("preemption handle is invalid: already unpreempted")
 	}
 
-	u.revertFn()
+	err := u.revertFn()
 	u.reverted = true
 
 	if !s.transactionInProgress {
 		s.undoLog.commit()
+	}
+
+	if err != nil {
+		return nil, err
 	}
 
 	return u.pods, nil

--- a/pkg/upstreamsync/snapshot/snapshot.go
+++ b/pkg/upstreamsync/snapshot/snapshot.go
@@ -381,13 +381,14 @@ func (s *ClusterSnapshot) Unpreempt(u *Unpreemption) ([]*v1.Pod, error) {
 		return nil, fmt.Errorf("preemption handle is invalid: already unpreempted")
 	}
 
+	defer func() {
+		u.reverted = true
+		if !s.transactionInProgress {
+			s.undoLog.commit()
+		}
+	}()
+
 	err := u.revertFn()
-	u.reverted = true
-
-	if !s.transactionInProgress {
-		s.undoLog.commit()
-	}
-
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/upstreamsync/snapshot/snapshot.go
+++ b/pkg/upstreamsync/snapshot/snapshot.go
@@ -35,19 +35,41 @@ import (
 // same underlying cache.Snapshot. Creating a new snapshot via ClusterState.Snapshot
 // updates that shared snapshot in-place, which invalidates any previously returned
 // ClusterSnapshot instance — callers must not use a prior snapshot after requesting a new one.
+// A ClusterSnapshot is not safe for concurrent use.
 type ClusterSnapshot struct {
-	profiles                  *upstreamsync.ProfileMap
-	schedulerSnapshot         *cache.Snapshot
-	undoLog                   undoLog
-	transactionInProgress     bool
+	// profiles holds the scheduling framework per scheduler name. All of them share
+	// schedulerSnapshot as their SnapshotSharedLister, so the plugins always see the mutations
+	// performed here.
+	profiles *upstreamsync.ProfileMap
+	// schedulerSnapshot is the upstream snapshot holding the actual node and pod data.
+	schedulerSnapshot *cache.Snapshot
+	// undoLog records how to undo every mutation applied to schedulerSnapshot, so that a dry run
+	// or a reverted transaction can restore the state it started from.
+	undoLog undoLog
+	// transactionInProgress guards against nested transactions and tells the mutating methods to
+	// leave the undo log alone, as the enclosing transaction owns it.
+	transactionInProgress bool
+	// stateVersionForPreemption is bumped whenever a mutation makes the outstanding Unpreemption
+	// handles unusable, i.e. whenever the state they would be restoring into is no longer the one
+	// they were taken from. Unpreempt compares it with the value recorded in the handle.
 	stateVersionForPreemption uint64
 }
 
+// undoLog is a stack of the operations reverting the mutations applied to the snapshot, most
+// recent last. Every mutation pushes its revert function, and rolling back means popping and
+// running them until the recorded state version is reached again.
 type undoLog struct {
+	// undoOperations are the revert functions, in the order their mutations were applied.
 	undoOperations []func()
-	stateVersion   uint64
+	// stateVersion is incremented by every registered operation and decremented by every undone
+	// one. A caller records it before mutating and passes it to restoreState afterwards to undo
+	// exactly its own mutations.
+	stateVersion uint64
 }
 
+// registerOperation pushes the revert function of a mutation that has just been applied.
+// A nil undoOperation is ignored, so that callers can pass the result of an operation that
+// did not change anything.
 func (ul *undoLog) registerOperation(undoOperation func()) {
 	if undoOperation != nil {
 		ul.undoOperations = append(ul.undoOperations, undoOperation)
@@ -55,12 +77,15 @@ func (ul *undoLog) registerOperation(undoOperation func()) {
 	}
 }
 
+// restoreState undoes the operations registered after the given state version was observed,
+// in the reverse order of their registration.
 func (ul *undoLog) restoreState(stateVersion uint64) {
 	for ul.stateVersion != stateVersion {
 		ul.undo()
 	}
 }
 
+// undo pops the most recently registered operation and runs it.
 func (ul *undoLog) undo() {
 	ops := ul.undoOperations
 	ops, undoOp := ops[:len(ops)-1], ops[len(ops)-1]
@@ -69,11 +94,19 @@ func (ul *undoLog) undo() {
 	ul.stateVersion--
 }
 
+// commit makes the mutations applied so far permanent by dropping the recorded revert functions.
+// The state version keeps growing across commits, as it is only ever compared against the markers
+// taken after the last commit; it is not an index into undoOperations.
 func (ul *undoLog) commit() {
 	ul.undoOperations = nil
 }
 
 // New creates a new ClusterSnapshot stub wrapping the provided scheduler snapshot and frameworks.
+//
+// Consumers should obtain a ClusterSnapshot from simulator.SchedulingSimulator instead, either via
+// NewClusterSnapshot or via NewClusterState followed by state.ClusterState.Snapshot: those build
+// the full plugin chain out of the KubeSchedulerConfiguration and initialize the scheduler metrics,
+// which this constructor expects to have been done already.
 func New(s *cache.Snapshot, profiles *upstreamsync.ProfileMap) *ClusterSnapshot {
 	return &ClusterSnapshot{
 		profiles:          profiles,
@@ -167,6 +200,8 @@ func schedulingResult(algRes *upstreamsync.AlgorithmResult) SchedulingResult {
 // StopOnFailure controls whether the first unschedulable pod stops the loop. Note that
 // All unexpected execution errors always propagate immediately regardless of StopOnFailure, as they
 // indicate a programming error rather than a scheduling failure.
+// Every pod that is scheduled gets its Spec.NodeName set to the selected node, which is also
+// reported by the corresponding SchedulingResult.
 func (s *ClusterSnapshot) SchedulePods(ctx context.Context, pods []*v1.Pod, placement *fwk.Placement, opts SchedulePodsOptions) ([]SchedulingResult, error) {
 	return s.schedulePods(ctx, slices.Values(pods), placement, opts)
 }

--- a/pkg/upstreamsync/snapshot/snapshot_test.go
+++ b/pkg/upstreamsync/snapshot/snapshot_test.go
@@ -24,6 +24,7 @@ import (
 	"github.com/google/go-cmp/cmp/cmpopts"
 	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/sets"
 	fwk "k8s.io/kube-scheduler/framework"
 	"k8s.io/kubernetes/pkg/scheduler/backend/cache"
 	st "k8s.io/kubernetes/pkg/scheduler/testing"
@@ -142,7 +143,7 @@ func canSchedule(podName string, candidateNodes []string) stepFn {
 	}
 }
 
-func verifySnapshot(expected map[string][]string) stepFn {
+func verifySnapshot(expected map[string]sets.Set[string]) stepFn {
 	return func(t *testing.T, sc *stepContext) {
 		t.Helper()
 		ft.VerifySnapshot(t, sc.snap, expected)
@@ -223,9 +224,9 @@ func TestSnapshot_ActionSequences(t *testing.T) {
 			assignedPods: map[string][]string{"node1": {"pod1"}},
 			steps: []stepFn{
 				preempt("u1", "pod1"),
-				verifySnapshot(map[string][]string{"node1": {}}),
+				verifySnapshot(map[string]sets.Set[string]{"node1": sets.New[string]()}),
 				unpreempt("u1"),
-				verifySnapshot(map[string][]string{"node1": {"pod1"}}),
+				verifySnapshot(map[string]sets.Set[string]{"node1": sets.New("pod1")}),
 			},
 		},
 		{
@@ -235,13 +236,13 @@ func TestSnapshot_ActionSequences(t *testing.T) {
 				inTransaction(Commit,
 					preempt("uA", "pod1"),
 					preempt("uB", "pod2"),
-					verifySnapshot(map[string][]string{"node1": {}}),
+					verifySnapshot(map[string]sets.Set[string]{"node1": sets.New[string]()}),
 					unpreempt("uA"),
-					verifySnapshot(map[string][]string{"node1": {"pod1"}}),
+					verifySnapshot(map[string]sets.Set[string]{"node1": sets.New("pod1")}),
 					unpreempt("uB"),
-					verifySnapshot(map[string][]string{"node1": {"pod1", "pod2"}}),
+					verifySnapshot(map[string]sets.Set[string]{"node1": sets.New("pod1", "pod2")}),
 				),
-				verifySnapshot(map[string][]string{"node1": {"pod1", "pod2"}}),
+				verifySnapshot(map[string]sets.Set[string]{"node1": sets.New("pod1", "pod2")}),
 			},
 		},
 		{
@@ -250,11 +251,11 @@ func TestSnapshot_ActionSequences(t *testing.T) {
 			steps: []stepFn{
 				inTransaction(Revert,
 					preempt("u1", "pod1"),
-					verifySnapshot(map[string][]string{"node1": {}}),
+					verifySnapshot(map[string]sets.Set[string]{"node1": sets.New[string]()}),
 					schedule([]string{"pod"}, []string{"node1"}, SchedulePodsOptions{}),
-					verifySnapshot(map[string][]string{"node1": {"pod"}}),
+					verifySnapshot(map[string]sets.Set[string]{"node1": sets.New("pod")}),
 				),
-				verifySnapshot(map[string][]string{"node1": {"pod1"}}),
+				verifySnapshot(map[string]sets.Set[string]{"node1": sets.New("pod1")}),
 			},
 		},
 		{
@@ -265,14 +266,14 @@ func TestSnapshot_ActionSequences(t *testing.T) {
 					preempt("u1", "pod1"),
 					preempt("u2", "pod2"),
 					preempt("u3", "pod3"),
-					verifySnapshot(map[string][]string{"node1": {}}),
+					verifySnapshot(map[string]sets.Set[string]{"node1": sets.New[string]()}),
 					// Out-of-order unpreemptions
 					unpreempt("u2"),
-					verifySnapshot(map[string][]string{"node1": {"pod2"}}),
+					verifySnapshot(map[string]sets.Set[string]{"node1": sets.New("pod2")}),
 					unpreempt("u1"),
-					verifySnapshot(map[string][]string{"node1": {"pod1", "pod2"}}),
+					verifySnapshot(map[string]sets.Set[string]{"node1": sets.New("pod1", "pod2")}),
 				),
-				verifySnapshot(map[string][]string{"node1": {"pod1", "pod2", "pod3"}}),
+				verifySnapshot(map[string]sets.Set[string]{"node1": sets.New("pod1", "pod2", "pod3")}),
 			},
 		},
 		{
@@ -280,7 +281,7 @@ func TestSnapshot_ActionSequences(t *testing.T) {
 			assignedPods: map[string][]string{"node1": {"pod1"}},
 			steps: []stepFn{
 				preemptErr("has no node name", "pod1", "podNoNode"),
-				verifySnapshot(map[string][]string{"node1": {"pod1"}}),
+				verifySnapshot(map[string]sets.Set[string]{"node1": sets.New("pod1")}),
 			},
 		},
 		{
@@ -318,7 +319,7 @@ func TestSnapshot_ActionSequences(t *testing.T) {
 				canSchedule("pod", []string{"node1"}),
 				schedule([]string{"pod"}, []string{"node1"}, NewSchedulePodsOptions(true, false)),
 				unpreempt("u1"),
-				verifySnapshot(map[string][]string{"node1": {"pod1"}}),
+				verifySnapshot(map[string]sets.Set[string]{"node1": sets.New("pod1")}),
 			},
 		},
 		{
@@ -375,9 +376,9 @@ func TestSnapshot_ActionSequences(t *testing.T) {
 			steps: []stepFn{
 				inTransactionReturnErr("simulated transaction error",
 					preempt("u1", "pod1"),
-					verifySnapshot(map[string][]string{"node1": {}}),
+					verifySnapshot(map[string]sets.Set[string]{"node1": sets.New[string]()}),
 				),
-				verifySnapshot(map[string][]string{"node1": {"pod1"}}),
+				verifySnapshot(map[string]sets.Set[string]{"node1": sets.New("pod1")}),
 			},
 		},
 		{
@@ -398,18 +399,18 @@ func TestSnapshot_ActionSequences(t *testing.T) {
 				inTransaction(Revert,
 					schedule([]string{"pod"}, []string{"singlePodNode"}, SchedulePodsOptions{}),
 					schedule([]string{"pod1"}, []string{"singlePodNode"}, SchedulePodsOptions{}),
-					verifySnapshot(map[string][]string{
-						"singlePodNode": {"pod"},
-						"node1":         {}}),
+					verifySnapshot(map[string]sets.Set[string]{
+						"singlePodNode": sets.New("pod"),
+						"node1":         sets.New[string]()}),
 					schedule([]string{"pod1"}, []string{"node1"}, SchedulePodsOptions{}),
-					verifySnapshot(map[string][]string{
-						"singlePodNode": {"pod"},
-						"node1":         {"pod1"}}),
+					verifySnapshot(map[string]sets.Set[string]{
+						"singlePodNode": sets.New("pod"),
+						"node1":         sets.New("pod1")}),
 				),
 				schedule([]string{"pod1"}, []string{"singlePodNode"}, SchedulePodsOptions{}),
-				verifySnapshot(map[string][]string{
-					"singlePodNode": {"pod1"},
-					"node1":         {}}),
+				verifySnapshot(map[string]sets.Set[string]{
+					"singlePodNode": sets.New("pod1"),
+					"node1":         sets.New[string]()}),
 			},
 		},
 	}
@@ -577,6 +578,26 @@ var scheduleResultCmpOpts = []cmp.Option{
 	}),
 }
 
+// podNameCmpOpt compares pods generated from a template by namespace and name, ignoring the random
+// UID that createPodFromTemplate appends to the name. The suffix is stripped from both sides,
+// as go-cmp requires the comparer to be symmetric; only the generated pod actually carries one.
+var podNameCmpOpt = cmp.Comparer(func(x, y *v1.Pod) bool {
+	if x == nil || y == nil {
+		return x == y
+	}
+	return x.Namespace == y.Namespace && trimGeneratedUID(x) == trimGeneratedUID(y)
+})
+
+// trimGeneratedUID drops the trailing "-<uid>" that createPodFromTemplate appends to the pod name,
+// leaving the deterministic "<template-name>-<index>" part. Pods carrying no UID - the expected
+// ones - keep their name as is.
+func trimGeneratedUID(p *v1.Pod) string {
+	if p.UID == "" {
+		return p.Name
+	}
+	return strings.TrimSuffix(p.Name, "-"+string(p.UID))
+}
+
 func TestSchedulePods(t *testing.T) {
 	node1 := st.MakeNode().Name("node1").Capacity(map[v1.ResourceName]string{v1.ResourcePods: "2"}).Obj()
 	node1Capacity1 := st.MakeNode().Name("node1").Capacity(map[v1.ResourceName]string{v1.ResourcePods: "1"}).Obj()
@@ -597,7 +618,7 @@ func TestSchedulePods(t *testing.T) {
 		candidateNodes      []string
 		opts                SchedulePodsOptions
 		expectResults       []SchedulingResult
-		expectSnapshotState map[string][]string
+		expectSnapshotState map[string]sets.Set[string]
 		expectErr           bool
 	}{
 		{
@@ -613,7 +634,7 @@ func TestSchedulePods(t *testing.T) {
 					Status:           fwk.NewStatus(fwk.Success),
 				},
 			},
-			expectSnapshotState: map[string][]string{"node1": {"pod1"}},
+			expectSnapshotState: map[string]sets.Set[string]{"node1": sets.New("pod1")},
 		},
 		{
 			name:           "DryRun - does not persist",
@@ -628,7 +649,7 @@ func TestSchedulePods(t *testing.T) {
 					Status:           fwk.NewStatus(fwk.Success),
 				},
 			},
-			expectSnapshotState: map[string][]string{"node1": nil},
+			expectSnapshotState: map[string]sets.Set[string]{"node1": nil},
 		},
 		{
 			name:                "StopOnFailure - fails on first pod",
@@ -637,7 +658,7 @@ func TestSchedulePods(t *testing.T) {
 			candidateNodes:      []string{"node1"},
 			opts:                NewSchedulePodsOptions(false, true),
 			expectResults:       nil,
-			expectSnapshotState: map[string][]string{"node1": nil},
+			expectSnapshotState: map[string]sets.Set[string]{"node1": nil},
 			expectErr:           true,
 		},
 		{
@@ -653,7 +674,7 @@ func TestSchedulePods(t *testing.T) {
 					Status:           fwk.NewStatus(fwk.Unschedulable),
 				},
 			},
-			expectSnapshotState: map[string][]string{"node1": nil},
+			expectSnapshotState: map[string]sets.Set[string]{"node1": nil},
 		},
 		{
 			name:           "Schedule over capacity without stopping on failure",
@@ -681,8 +702,8 @@ func TestSchedulePods(t *testing.T) {
 					Status: fwk.NewStatus(fwk.Unschedulable),
 				},
 			},
-			expectSnapshotState: map[string][]string{
-				"node1": {"pod1", "pod2"},
+			expectSnapshotState: map[string]sets.Set[string]{
+				"node1": sets.New("pod1", "pod2"),
 			},
 		},
 		{
@@ -707,8 +728,8 @@ func TestSchedulePods(t *testing.T) {
 					Status: fwk.NewStatus(fwk.Unschedulable),
 				},
 			},
-			expectSnapshotState: map[string][]string{
-				"node1": {"pod1", "pod2"},
+			expectSnapshotState: map[string]sets.Set[string]{
+				"node1": sets.New("pod1", "pod2"),
 			},
 		},
 		{
@@ -729,7 +750,7 @@ func TestSchedulePods(t *testing.T) {
 					Status:           fwk.NewStatus(fwk.Unschedulable),
 				},
 			},
-			expectSnapshotState: map[string][]string{"node1": {"pod1"}, "node2": nil},
+			expectSnapshotState: map[string]sets.Set[string]{"node1": sets.New("pod1"), "node2": nil},
 		},
 		{
 			name:           "StopOnFailure - stops on first failure even if more pods could be scheduled",
@@ -749,7 +770,7 @@ func TestSchedulePods(t *testing.T) {
 					Status:           fwk.NewStatus(fwk.Unschedulable),
 				},
 			},
-			expectSnapshotState: map[string][]string{"node1": {"pod1"}, "node2": nil},
+			expectSnapshotState: map[string]sets.Set[string]{"node1": sets.New("pod1"), "node2": nil},
 		},
 		{
 			name:           "Error outside transaction - rolls back previous successful pods",
@@ -764,7 +785,7 @@ func TestSchedulePods(t *testing.T) {
 					Status:           fwk.NewStatus(fwk.Success),
 				},
 			},
-			expectSnapshotState: map[string][]string{"node1": nil},
+			expectSnapshotState: map[string]sets.Set[string]{"node1": nil},
 			expectErr:           true,
 		},
 	}
@@ -789,6 +810,16 @@ func TestSchedulePods(t *testing.T) {
 				t.Errorf("Unexpected scheduling results (-want +got):\n%s", diff)
 			}
 
+			// SchedulePods reflects the selected node on the pods it was given.
+			for _, res := range results {
+				if !res.Status.IsSuccess() {
+					continue
+				}
+				if res.Pod.Spec.NodeName != res.SelectedNodeName {
+					t.Errorf("expected pod %s to have NodeName %q, got %q", res.Pod.Name, res.SelectedNodeName, res.Pod.Spec.NodeName)
+				}
+			}
+
 			ft.VerifySnapshot(t, snap, tc.expectSnapshotState)
 		})
 	}
@@ -803,8 +834,16 @@ func TestSchedulePodsByTemplate(t *testing.T) {
 		Spec:       v1.PodSpec{},
 	}
 
-	generatedPod := &v1.Pod{ObjectMeta: metav1.ObjectMeta{Name: "templated-pod", Namespace: "default"}}
-	generatedNSPod := &v1.Pod{ObjectMeta: metav1.ObjectMeta{Name: "templated-pod-0-", Namespace: "custom-ns"}}
+	// createPodFromTemplate names the pods it generates "<template-name>-<index>-<uuid>", and the
+	// UUID is random. The expected pods below therefore carry only the deterministic part of the
+	// name, and podNameCmpOpt strips the UUID suffix from the generated one before comparing.
+	// Keeping the index in the expectation makes the comparison exact.
+	generatedPod := func(index int) *v1.Pod {
+		return &v1.Pod{ObjectMeta: metav1.ObjectMeta{Name: fmt.Sprintf("templated-pod-%d", index), Namespace: "default"}}
+	}
+	generatedNSPod := func(index int) *v1.Pod {
+		return &v1.Pod{ObjectMeta: metav1.ObjectMeta{Name: fmt.Sprintf("templated-pod-%d", index), Namespace: "custom-ns"}}
+	}
 
 	tests := []struct {
 		name                string
@@ -826,12 +865,12 @@ func TestSchedulePodsByTemplate(t *testing.T) {
 			opts:           SchedulePodsByTemplateOptions{},
 			expectResults: []SchedulingResult{
 				{
-					Pod:              generatedPod,
+					Pod:              generatedPod(0),
 					SelectedNodeName: "node1",
 					Status:           fwk.NewStatus(fwk.Success),
 				},
 				{
-					Pod:              generatedPod,
+					Pod:              generatedPod(1),
 					SelectedNodeName: "node1",
 					Status:           fwk.NewStatus(fwk.Success),
 				},
@@ -848,22 +887,22 @@ func TestSchedulePodsByTemplate(t *testing.T) {
 			opts:           SchedulePodsByTemplateOptions{},
 			expectResults: []SchedulingResult{
 				{
-					Pod:              generatedPod,
+					Pod:              generatedPod(0),
 					SelectedNodeName: "node1",
 					Status:           fwk.NewStatus(fwk.Success),
 				},
 				{
-					Pod:              generatedPod,
+					Pod:              generatedPod(1),
 					SelectedNodeName: "node1",
 					Status:           fwk.NewStatus(fwk.Success),
 				},
 				{
-					Pod:              generatedPod,
+					Pod:              generatedPod(2),
 					SelectedNodeName: "node1",
 					Status:           fwk.NewStatus(fwk.Success),
 				},
 				{
-					Pod:    generatedPod,
+					Pod:    generatedPod(3),
 					Status: fwk.NewStatus(fwk.Unschedulable),
 				},
 			},
@@ -901,12 +940,12 @@ func TestSchedulePodsByTemplate(t *testing.T) {
 			opts:           NewSchedulePodsByTemplateOptions(true),
 			expectResults: []SchedulingResult{
 				{
-					Pod:              generatedPod,
+					Pod:              generatedPod(0),
 					SelectedNodeName: "node1",
 					Status:           fwk.NewStatus(fwk.Success),
 				},
 				{
-					Pod:              generatedPod,
+					Pod:              generatedPod(1),
 					SelectedNodeName: "node1",
 					Status:           fwk.NewStatus(fwk.Success),
 				},
@@ -923,7 +962,7 @@ func TestSchedulePodsByTemplate(t *testing.T) {
 			opts:           SchedulePodsByTemplateOptions{},
 			expectResults: []SchedulingResult{
 				{
-					Pod:              generatedNSPod,
+					Pod:              generatedNSPod(0),
 					SelectedNodeName: "node1",
 					Status:           fwk.NewStatus(fwk.Success),
 				},
@@ -951,12 +990,7 @@ func TestSchedulePodsByTemplate(t *testing.T) {
 
 			var opts []cmp.Option
 			opts = append(opts, scheduleResultCmpOpts...)
-			opts = append(opts, cmp.Comparer(func(x, y *v1.Pod) bool {
-				if x == nil || y == nil {
-					return x == y
-				}
-				return x.Namespace == y.Namespace && (strings.HasPrefix(x.Name, y.Name) || strings.HasPrefix(y.Name, x.Name))
-			}))
+			opts = append(opts, podNameCmpOpt)
 
 			if diff := cmp.Diff(tc.expectResults, results, opts...); diff != "" {
 				t.Errorf("Unexpected scheduling results (-want +got):\n%s", diff)

--- a/pkg/upstreamsync/snapshot/types.go
+++ b/pkg/upstreamsync/snapshot/types.go
@@ -27,15 +27,24 @@ type CommonSchedulingOptions struct {
 	DryRun bool
 }
 
+// SchedulePodsOptions are the options of ClusterSnapshot.SchedulePods.
 type SchedulePodsOptions struct {
 	CommonSchedulingOptions
+	// StopOnFailure determines whether the first pod that cannot be scheduled ends the whole
+	// call. When false, the remaining pods are still attempted and the returned results hold one
+	// entry per attempted pod. Unexpected execution errors always end the call regardless of
+	// this option, as they indicate a programming error rather than a scheduling failure.
 	StopOnFailure bool
 }
 
+// SchedulePodsByTemplateOptions are the options of ClusterSnapshot.SchedulePodsByTemplate.
+// The method always stops at the first pod that does not fit, as the pods it schedules are
+// identical and the next one would not fit either.
 type SchedulePodsByTemplateOptions struct {
 	CommonSchedulingOptions
 }
 
+// NewSchedulePodsOptions builds the SchedulePodsOptions out of its individual fields.
 func NewSchedulePodsOptions(dryRun bool, stopOnFailure bool) SchedulePodsOptions {
 	return SchedulePodsOptions{
 		CommonSchedulingOptions: CommonSchedulingOptions{DryRun: dryRun},
@@ -43,28 +52,47 @@ func NewSchedulePodsOptions(dryRun bool, stopOnFailure bool) SchedulePodsOptions
 	}
 }
 
+// NewSchedulePodsByTemplateOptions builds the SchedulePodsByTemplateOptions out of its individual fields.
 func NewSchedulePodsByTemplateOptions(dryRun bool) SchedulePodsByTemplateOptions {
 	return SchedulePodsByTemplateOptions{
 		CommonSchedulingOptions: CommonSchedulingOptions{DryRun: dryRun},
 	}
 }
 
+// TransactionResult is what the function passed to ClusterSnapshot.Transaction returns to decide
+// the fate of the mutations it made.
 type TransactionResult int
 
 const (
+	// Commit keeps the mutations made within the transaction.
 	Commit TransactionResult = iota
+	// Revert undoes all the mutations made within the transaction.
 	Revert
 )
 
+// SchedulingResult is the outcome of a single pod scheduling attempt.
 type SchedulingResult struct {
-	Pod              *v1.Pod
-	Status           *fwk.Status
+	// Pod is the pod the attempt was made for. For the pods created from a template it is the
+	// generated pod, which is the only way for the caller to learn what was scheduled.
+	Pod *v1.Pod
+	// Status is the outcome of the scheduling cycle: success, or the reason the pod was rejected.
+	Status *fwk.Status
+	// SelectedNodeName is the node the pod was scheduled on, empty if it was not scheduled.
 	SelectedNodeName string
 }
 
+// Unpreemption is the handle returned by ClusterSnapshot.PreemptPods, allowing the preempted pods
+// to be put back with ClusterSnapshot.Unpreempt. It is single-use and is tied to the state of the
+// snapshot it was taken from: any permanent mutation of that snapshot invalidates it, since the
+// pods it holds could no longer be restored to the state they were removed from.
 type Unpreemption struct {
-	pods                   []*v1.Pod
-	revertFn               func()
-	reverted               bool
+	// pods are the pods that were preempted, returned to the caller by Unpreempt.
+	pods []*v1.Pod
+	// revertFn puts the pods back into the snapshot, registering the undo of each addition.
+	revertFn func()
+	// reverted marks the handle as consumed, so that it cannot be applied twice.
+	reverted bool
+	// validPreemptionVersion is the snapshot's preemption state version at the time of the
+	// preemption. Unpreempt refuses to run once the snapshot has moved past it.
 	validPreemptionVersion uint64
 }

--- a/pkg/upstreamsync/snapshot/types.go
+++ b/pkg/upstreamsync/snapshot/types.go
@@ -89,7 +89,7 @@ type Unpreemption struct {
 	// pods are the pods that were preempted, returned to the caller by Unpreempt.
 	pods []*v1.Pod
 	// revertFn puts the pods back into the snapshot, registering the undo of each addition.
-	revertFn func()
+	revertFn func() error
 	// reverted marks the handle as consumed, so that it cannot be applied twice.
 	reverted bool
 	// validPreemptionVersion is the snapshot's preemption state version at the time of the


### PR DESCRIPTION
## What this PR does / why we need it

Follow-up to the initial library implementation (#2). The code was there, but nothing said where a
consumer should start, which packages are API and which are temporary upstream debt, or which lines
of the copied kube-scheduler code were changed and why. This PR fills that in, plus the few fixes
the documentation pass surfaced. Roughly 70% of the added lines are comments.

* **Docs.** Package docs for `pkg/simulator` (the entry point: setup, obtaining a snapshot, the
  simulation methods), `pkg/upstreamsync` and `pkg/upstreamsync/snapshot`, an "Entry points"
  section in the README, and doc comments on the exported types and on the internals whose
  invariants are not obvious (the undo log, the preemption state version).

* **The `UPSTREAM-DIFF:` convention.** CONTRIBUTING.md now requires copied kube-scheduler code to
  keep the upstream comments verbatim and to mark every intentional deviation with an
  `UPSTREAM-DIFF:` comment saying what changed and why, so that `grep -rn "UPSTREAM-DIFF:" pkg/`
  lists everything to reconcile before upstreaming. The convention is applied across
  `pkg/upstreamsync`, and the incorrect "Extracted from" paths were fixed.

* **Behaviour.** `Unpreempt` now reports the errors of putting the preempted pods back instead of
  dropping them silently, and the scheduled pod's `Spec.NodeName` is set by `SchedulePods` rather
  than deep in the per-pod helper. No change to the scheduling algorithm itself.

* **Tooling.** `gofmt` and `goimports` enabled in `.golangci.yaml`.

## Special notes for your reviewer

Mostly comments. Worth actual review: the `Unpreempt` error handling, the moved `Spec.NodeName`
assignment, and whether each `UPSTREAM-DIFF:` note is accurate.

## Does this PR introduce a user-facing change?

```release-note
NONE