### PR TITLE
Revert snapshot mutations before updating it

### DIFF
--- a/pkg/simulator/simulator_test.go
+++ b/pkg/simulator/simulator_test.go
@@ -413,7 +413,8 @@ func TestClusterState_Scheduling(t *testing.T) {
 	}
 	state.Cache.AddNode(klog.FromContext(ctx), node)
 
-	snap, err := state.Snapshot(klog.FromContext(ctx))
+	snap := state.GetAssociatedSnapshot()
+	err = state.SyncSnapshot(klog.FromContext(ctx))
 	if err != nil {
 		t.Fatalf("failed to take snapshot: %v", err)
 	}

--- a/pkg/state/state.go
+++ b/pkg/state/state.go
@@ -25,28 +25,35 @@ import (
 )
 
 type ClusterState struct {
-	Cache      cache.Cache
-	profiles   *upstreamsync.ProfileMap
-	sharedSnap *cache.Snapshot
+	Cache        cache.Cache
+	snapshot     *snapshot.ClusterSnapshot
+	snapshotData *cache.Snapshot
 }
 
 // New creates a new ClusterState with an internal Kubernetes scheduler cache, frameworks,
 // and the snapshot instance shared with all frameworks via WithSnapshotSharedLister.
 func New(c cache.Cache, profiles *upstreamsync.ProfileMap, snap *cache.Snapshot) *ClusterState {
 	return &ClusterState{
-		Cache:      c,
-		profiles:   profiles,
-		sharedSnap: snap,
+		Cache:        c,
+		snapshot:     snapshot.New(snap, profiles),
+		snapshotData: snap,
 	}
 }
 
-// Snapshot constructs a snapshot from the current cluster state by updating the shared snapshot
-// in-place. Calling Snapshot again invalidates any previously returned ClusterSnapshot — the caller
-// must not use a previous snapshot after requesting a new one.
-func (s *ClusterState) Snapshot(logger klog.Logger) (*snapshot.ClusterSnapshot, error) {
-	snap := s.sharedSnap
-	if err := s.Cache.UpdateSnapshot(logger, snap); err != nil {
-		return nil, fmt.Errorf("failed to update snapshot: %w", err)
+// GetAssociatedSnapshot returns the snapshot instance associated with this [ClusterState].
+// Use [ClusterState.SyncSnapshot] to sync the snapshot state with the current cluster state.
+func (s *ClusterState) GetAssociatedSnapshot() *snapshot.ClusterSnapshot {
+	return s.snapshot
+}
+
+// SyncSnapshot uses the current cluster state to update the associated snapshot in-place.
+// Any mutations done on the snapshot since last sync will be reverted.
+func (s *ClusterState) SyncSnapshot(logger klog.Logger) error {
+	if err := s.snapshot.ResetMutations(); err != nil {
+		return fmt.Errorf("failed to reset mutations: %w", err)
 	}
-	return snapshot.New(snap, s.profiles), nil
+	if err := s.Cache.UpdateSnapshot(logger, s.snapshotData); err != nil {
+		return fmt.Errorf("failed to update snapshot: %w", err)
+	}
+	return nil
 }

--- a/pkg/state/state_test.go
+++ b/pkg/state/state_test.go
@@ -31,6 +31,7 @@ import (
 	"sigs.k8s.io/scheduler-library/pkg/framework"
 	ft "sigs.k8s.io/scheduler-library/pkg/framework/testing"
 	"sigs.k8s.io/scheduler-library/pkg/upstreamsync"
+	"sigs.k8s.io/scheduler-library/pkg/upstreamsync/snapshot"
 )
 
 func init() {
@@ -87,12 +88,9 @@ func TestClusterState_AddPod(t *testing.T) {
 			}
 
 			ft.VerifySnapshot(t, sharedSnap, nil)
-			csnap, err := state.Snapshot(logger)
+			err = state.SyncSnapshot(logger)
 			if err != nil {
 				t.Fatalf("Snapshot() error = %v", err)
-			}
-			if csnap == nil {
-				t.Fatal("Expected ClusterSnapshot to be non-nil")
 			}
 
 			ft.VerifySnapshot(t, sharedSnap, tc.expected)
@@ -148,12 +146,9 @@ func TestClusterState_RemovePod(t *testing.T) {
 			}
 
 			ft.VerifySnapshot(t, sharedSnap, nil)
-			csnap, err := state.Snapshot(logger)
+			err = state.SyncSnapshot(logger)
 			if err != nil {
 				t.Fatalf("Snapshot() error = %v", err)
-			}
-			if csnap == nil {
-				t.Fatal("Expected ClusterSnapshot to be non-nil")
 			}
 
 			ft.VerifySnapshot(t, sharedSnap, tc.expected)
@@ -209,12 +204,9 @@ func TestClusterState_AddNode(t *testing.T) {
 			state.Cache.AddNode(logger, tc.nodeToAdd)
 
 			ft.VerifySnapshot(t, sharedSnap, nil)
-			csnap, err := state.Snapshot(logger)
+			err := state.SyncSnapshot(logger)
 			if err != nil {
 				t.Fatalf("Snapshot() error = %v", err)
-			}
-			if csnap == nil {
-				t.Fatal("Expected ClusterSnapshot to be non-nil")
 			}
 
 			ft.VerifySnapshot(t, sharedSnap, tc.expected)
@@ -266,12 +258,9 @@ func TestClusterState_RemoveNode(t *testing.T) {
 			}
 
 			ft.VerifySnapshot(t, sharedSnap, nil)
-			csnap, err := state.Snapshot(logger)
+			err = state.SyncSnapshot(logger)
 			if err != nil {
 				t.Fatalf("Snapshot() error = %v", err)
-			}
-			if csnap == nil {
-				t.Fatal("Expected ClusterSnapshot to be non-nil")
 			}
 
 			ft.VerifySnapshot(t, sharedSnap, tc.expected)
@@ -356,12 +345,9 @@ func TestClusterState_Snapshot(t *testing.T) {
 			}
 
 			ft.VerifySnapshot(t, sharedSnap, nil)
-			csnap, err := state.Snapshot(logger)
+			err := state.SyncSnapshot(logger)
 			if err != nil {
 				t.Fatalf("Snapshot() error = %v", err)
-			}
-			if csnap == nil {
-				t.Fatal("Expected ClusterSnapshot to be non-nil")
 			}
 
 			ft.VerifySnapshot(t, sharedSnap, tc.expected)
@@ -406,12 +392,9 @@ func TestClusterState_SequentialUpdates(t *testing.T) {
 	updateSnapshot := func() action {
 		return func(t *testing.T, state *ClusterState) {
 			t.Helper()
-			csnap, err := state.Snapshot(klog.FromContext(t.Context()))
+			err := state.SyncSnapshot(klog.FromContext(t.Context()))
 			if err != nil {
 				t.Fatalf("Snapshot() error = %v", err)
-			}
-			if csnap == nil {
-				t.Fatal("Expected ClusterSnapshot to be non-nil")
 			}
 		}
 	}
@@ -419,7 +402,7 @@ func TestClusterState_SequentialUpdates(t *testing.T) {
 	assertSnapshot := func(expected map[string]sets.Set[string]) action {
 		return func(t *testing.T, state *ClusterState) {
 			t.Helper()
-			ft.VerifySnapshot(t, state.sharedSnap, expected)
+			ft.VerifySnapshot(t, state.snapshotData, expected)
 		}
 	}
 
@@ -479,4 +462,75 @@ func newDummyProfileMap() *upstreamsync.ProfileMap {
 	return &upstreamsync.ProfileMap{
 		Map: make(profile.Map),
 	}
+}
+
+func TestClusterState_SyncSnapshot_RevertsMutations(t *testing.T) {
+	ctx := t.Context()
+	logger := klog.FromContext(ctx)
+	sharedSnap := cache.NewEmptySnapshot()
+
+	informerFactory := informers.NewSharedInformerFactory(fake.NewClientset(), 0)
+	registry := plugins.NewInTreeRegistry()
+	prof := schedulerapi.KubeSchedulerProfile{
+		SchedulerName: "default-scheduler",
+	}
+	fwk, err := frameworkruntime.NewFramework(ctx, registry, &prof,
+		frameworkruntime.WithSnapshotSharedLister(sharedSnap),
+		frameworkruntime.WithInformerFactory(informerFactory),
+	)
+	if err != nil {
+		t.Fatalf("Failed to create framework: %v", err)
+	}
+	profiles := &upstreamsync.ProfileMap{
+		Map: profile.Map{
+			"default-scheduler": fwk,
+		},
+	}
+
+	state := New(cache.New(ctx, nil, false), profiles, sharedSnap)
+
+	node1 := st.MakeNode().Name("node1").Capacity(map[v1.ResourceName]string{
+		v1.ResourceCPU:    "10",
+		v1.ResourceMemory: "10Gi",
+		v1.ResourcePods:   "110",
+	}).Obj()
+	pod1 := st.MakePod().Name("pod1").Namespace("default").UID("uid-pod1").Node("node1").Obj()
+	pod2 := st.MakePod().Name("pod2").Namespace("default").UID("uid-pod2").Obj()
+
+	state.Cache.AddNode(logger, node1)
+	if err := state.Cache.AddPod(logger, pod1); err != nil {
+		t.Fatalf("AddPod failed: %v", err)
+	}
+
+	err = state.SyncSnapshot(logger)
+	if err != nil {
+		t.Fatalf("SyncSnapshot failed: %v", err)
+	}
+	ft.VerifySnapshot(t, sharedSnap, map[string]sets.Set[string]{"node1": sets.New("pod1")})
+
+	csnap := state.GetAssociatedSnapshot()
+
+	placement, err := csnap.MakePlacement([]string{"node1"})
+	if err != nil {
+		t.Fatalf("MakePlacement failed: %v", err)
+	}
+
+	// Mutate snapshot by scheduling pod2
+	_, err = csnap.SchedulePods(ctx, []*v1.Pod{pod2}, placement, snapshot.SchedulePodsOptions{})
+	if err != nil {
+		t.Fatalf("SchedulePods failed: %v", err)
+	}
+	ft.VerifySnapshot(t, sharedSnap, map[string]sets.Set[string]{"node1": sets.New("pod1", "pod2")})
+
+	// Calling SyncSnapshot must revert snapshot mutations (pod2 scheduling)
+	err = state.SyncSnapshot(logger)
+	if err != nil {
+		t.Fatalf("SyncSnapshot failed: %v", err)
+	}
+
+	csnap2 := state.GetAssociatedSnapshot()
+	if csnap2 != csnap {
+		t.Errorf("Expected SyncSnapshot to return the same snapshot instance")
+	}
+	ft.VerifySnapshot(t, sharedSnap, map[string]sets.Set[string]{"node1": sets.New("pod1")})
 }

--- a/pkg/upstreamsync/mutable_snapshot.go
+++ b/pkg/upstreamsync/mutable_snapshot.go
@@ -15,6 +15,8 @@
 package upstreamsync
 
 import (
+	"fmt"
+
 	v1 "k8s.io/api/core/v1"
 	"k8s.io/klog/v2"
 	fwk "k8s.io/kube-scheduler/framework"
@@ -68,6 +70,14 @@ func (s *MutatingSnapshot) RemovePod(logger klog.Logger, podInfo *framework.PodI
 		return err
 	}
 
+	fni, ok := ni.(*framework.NodeInfo)
+	if !ok {
+		return fmt.Errorf("unknown node info type: %T", ni)
+	}
+	oldGen := fni.Generation
+	defer func() {
+		fni.Generation = oldGen
+	}()
 	err = ni.RemovePod(logger, podInfo.Pod)
 	if err != nil {
 		return err
@@ -92,6 +102,14 @@ func (s *MutatingSnapshot) AddPod(logger klog.Logger, podInfo *framework.PodInfo
 		return err
 	}
 
+	fni, ok := ni.(*framework.NodeInfo)
+	if !ok {
+		return fmt.Errorf("unknown node info type: %T", ni)
+	}
+	oldGen := fni.Generation
+	defer func() {
+		fni.Generation = oldGen
+	}()
 	ni.AddPodInfo(podInfo)
 
 	if _, ok := s.removedPods[key]; ok {

--- a/pkg/upstreamsync/snapshot/snapshot.go
+++ b/pkg/upstreamsync/snapshot/snapshot.go
@@ -95,13 +95,6 @@ func (ul *undoLog) undo() {
 	ul.stateVersion--
 }
 
-// commit makes the mutations applied so far permanent by dropping the recorded revert functions.
-// The state version keeps growing across commits, as it is only ever compared against the markers
-// taken after the last commit; it is not an index into undoOperations.
-func (ul *undoLog) commit() {
-	ul.undoOperations = nil
-}
-
 // New creates a new ClusterSnapshot stub wrapping the provided scheduler snapshot and frameworks.
 //
 // Consumers should obtain a ClusterSnapshot from simulator.SchedulingSimulator instead, either via
@@ -115,10 +108,25 @@ func New(s *cache.Snapshot, profiles *upstreamsync.ProfileMap) *ClusterSnapshot 
 	}
 }
 
+// ResetMutations restores the snapshot to its state prior to any mutations,
+// executing all accumulated undo operations in reverse order.
+func (s *ClusterSnapshot) ResetMutations() error {
+	if s.transactionInProgress {
+		return fmt.Errorf("transaction is in progress, cannot reset mutations")
+	}
+	if s.undoLog.stateVersion > 0 {
+		s.undoLog.restoreState(0)
+		s.stateVersionForPreemption++
+	}
+	return nil
+}
+
 // Transaction executes the provided function within a transaction.
 // It rolls back operations if the function returns Revert or an error.
 // Only a single active transaction is supported at any given time;
 // attempting to start a nested transaction will return an error.
+// Committed operations or operations made outside of transaction scope
+// can only be reverted by [ClusterSnapshot.ResetMutations].
 func (s *ClusterSnapshot) Transaction(ctx context.Context, transactionFn func() (TransactionResult, error)) error {
 	if s.transactionInProgress {
 		return fmt.Errorf("a transaction is already in progress")
@@ -137,7 +145,6 @@ func (s *ClusterSnapshot) Transaction(ctx context.Context, transactionFn func() 
 		s.undoLog.restoreState(initialStateVersion)
 		s.stateVersionForPreemption = initialStateVersionForPreemption
 	} else {
-		s.undoLog.commit()
 		// invalidate preemptions done within the transaction
 		s.stateVersionForPreemption++
 	}
@@ -245,9 +252,6 @@ func (s *ClusterSnapshot) schedulePods(ctx context.Context, pods iter.Seq[*v1.Po
 		if initialStateVersion != s.undoLog.stateVersion {
 			s.stateVersionForPreemption++
 		}
-		if !s.transactionInProgress {
-			s.undoLog.commit()
-		}
 	}()
 
 	result := make([]SchedulingResult, 0)
@@ -322,9 +326,6 @@ func (s *ClusterSnapshot) PreemptPods(ctx context.Context, pods []*v1.Pod) (_ *U
 		if err != nil {
 			s.undoLog.restoreState(initialStateVersion)
 		}
-		if !s.transactionInProgress {
-			s.undoLog.commit()
-		}
 	}()
 
 	mutatingSnapshot := upstreamsync.NewMutatingSnapshot(s.schedulerSnapshot)
@@ -383,9 +384,6 @@ func (s *ClusterSnapshot) Unpreempt(u *Unpreemption) ([]*v1.Pod, error) {
 
 	defer func() {
 		u.reverted = true
-		if !s.transactionInProgress {
-			s.undoLog.commit()
-		}
 	}()
 
 	err := u.revertFn()

--- a/pkg/upstreamsync/snapshot/snapshot_test.go
+++ b/pkg/upstreamsync/snapshot/snapshot_test.go
@@ -193,6 +193,25 @@ func expectNestedTxErr() stepFn {
 	}
 }
 
+func resetMutations() stepFn {
+	return func(t *testing.T, sc *stepContext) {
+		t.Helper()
+		if err := sc.cs.ResetMutations(); err != nil {
+			t.Fatalf("ResetMutations failed: %v", err)
+		}
+	}
+}
+
+func resetMutationsErr(wantErr string) stepFn {
+	return func(t *testing.T, sc *stepContext) {
+		t.Helper()
+		err := sc.cs.ResetMutations()
+		if err == nil || !strings.Contains(err.Error(), wantErr) {
+			t.Fatalf("ResetMutations expected error containing %q, got: %v", wantErr, err)
+		}
+	}
+}
+
 func TestSnapshot_ActionSequences(t *testing.T) {
 	ctx := context.Background()
 	nodes := []*v1.Node{
@@ -411,6 +430,44 @@ func TestSnapshot_ActionSequences(t *testing.T) {
 				verifySnapshot(map[string]sets.Set[string]{
 					"singlePodNode": sets.New("pod1"),
 					"node1":         sets.New[string]()}),
+			},
+		},
+		{
+			name:         "ResetMutations reverts scheduled pods and preemptions",
+			assignedPods: map[string][]string{"node1": {"pod1"}},
+			steps: []stepFn{
+				preempt("u1", "pod1"),
+				schedule([]string{"pod2"}, []string{"node1"}, SchedulePodsOptions{}),
+				verifySnapshot(map[string]sets.Set[string]{"node1": sets.New("pod2")}),
+				resetMutations(),
+				verifySnapshot(map[string]sets.Set[string]{"node1": sets.New("pod1")}),
+			},
+		},
+		{
+			name:         "ResetMutations invalidates preemption handles",
+			assignedPods: map[string][]string{"node1": {"pod1"}},
+			steps: []stepFn{
+				preempt("u1", "pod1"),
+				resetMutations(),
+				unpreemptErr("u1", "preemption handle is invalid: snapshot has been permanently mutated since preemption"),
+				verifySnapshot(map[string]sets.Set[string]{"node1": sets.New("pod1")}),
+			},
+		},
+		{
+			name:         "ResetMutations on empty mutations is no-op",
+			assignedPods: map[string][]string{"node1": {"pod1"}},
+			steps: []stepFn{
+				resetMutations(),
+				verifySnapshot(map[string]sets.Set[string]{"node1": sets.New("pod1")}),
+			},
+		},
+		{
+			name:         "ResetMutations inside transaction returns error",
+			assignedPods: map[string][]string{"node1": {"pod1"}},
+			steps: []stepFn{
+				inTransaction(Commit,
+					resetMutationsErr("transaction is in progress, cannot reset mutations"),
+				),
 			},
 		},
 	}
@@ -998,5 +1055,68 @@ func TestSchedulePodsByTemplate(t *testing.T) {
 
 			ft.VerifySnapshotPodCounts(t, snap, tc.expectSnapshotState)
 		})
+	}
+}
+
+func TestResetMutations_NodeGenerationRestored(t *testing.T) {
+	ctx := context.Background()
+
+	node1 := st.MakeNode().Name("node1").Capacity(map[v1.ResourceName]string{
+		v1.ResourceCPU:    "10",
+		v1.ResourceMemory: "10Gi",
+		v1.ResourcePods:   "110",
+	}).Obj()
+	node2 := st.MakeNode().Name("node2").Capacity(map[v1.ResourceName]string{
+		v1.ResourceCPU:    "10",
+		v1.ResourceMemory: "10Gi",
+		v1.ResourcePods:   "110",
+	}).Obj()
+
+	pod1 := st.MakePod().Name("pod1").Namespace("default").UID("uid-pod1").Node("node1").Obj()
+	pod2 := st.MakePod().Name("pod2").Namespace("default").UID("uid-pod2").Node("node2").Obj()
+	pod3 := st.MakePod().Name("pod3").Namespace("default").UID("uid-pod3").Obj()
+
+	cs, snap, _ := setupSnapshotTest(t, ctx, []*v1.Node{node1, node2}, []*v1.Pod{pod1, pod2})
+
+	getGenerations := func() map[string]int64 {
+		t.Helper()
+		generations := make(map[string]int64)
+		nodes, err := snap.NodeInfos().List()
+		if err != nil {
+			t.Fatalf("NodeInfos().List() failed: %v", err)
+		}
+		for _, node := range nodes {
+			generations[node.Node().Name] = node.GetGeneration()
+		}
+		return generations
+	}
+
+	// Record initial generations for all nodes
+	initialGenerations := getGenerations()
+
+	// Update node1 by removing pod1 from it
+	_, err := cs.PreemptPods(ctx, []*v1.Pod{pod1})
+	if err != nil {
+		t.Fatalf("PreemptPods failed: %v", err)
+	}
+
+	placement, err := cs.MakePlacement([]string{"node2"})
+	if err != nil {
+		t.Fatalf("MakePlacement failed: %v", err)
+	}
+
+	// Update node2 by scheduling pod3 to it
+	_, err = cs.SchedulePods(ctx, []*v1.Pod{pod3}, placement, SchedulePodsOptions{})
+	if err != nil {
+		t.Fatalf("SchedulePods failed: %v", err)
+	}
+
+	if err := cs.ResetMutations(); err != nil {
+		t.Fatalf("ResetMutations failed: %v", err)
+	}
+
+	// Compare generations after reset with initial generations
+	if diff := cmp.Diff(initialGenerations, getGenerations()); diff != "" {
+		t.Errorf("Generations don't match (-want +got):\n%s", diff)
 	}
 }

--- a/test/integration/scheduler/simulator_integration_test.go
+++ b/test/integration/scheduler/simulator_integration_test.go
@@ -104,7 +104,8 @@ func TestSimulatorIntegrationFlow(t *testing.T) {
 	}
 
 	// 5. Take snapshot and run simulations
-	snap, err := cs.Snapshot(logger)
+	snap := cs.GetAssociatedSnapshot()
+	err = cs.SyncSnapshot(logger)
 	if err != nil {
 		t.Fatalf("Snapshot failed: %v", err)
 	}
@@ -150,5 +151,20 @@ func TestSimulatorIntegrationFlow(t *testing.T) {
 	}
 	if len(feasibleNodes) != 0 {
 		t.Errorf("Expected hugePod to not fit on node1 due to CPU capacity, but got feasible nodes: %v", feasibleNodes)
+	}
+
+	// 6. SyncSnapshot should revert snapshot mutations (simPod scheduling)
+	err = cs.SyncSnapshot(logger)
+	if err != nil {
+		t.Fatalf("SyncSnapshot failed: %v", err)
+	}
+
+	// After SyncSnapshot reverts mutations, hugePod should fit on node1 again (2 existing CPU + 6 = 8 <= 10 CPU capacity)
+	feasibleNodes, diag, err = snap.CanSchedulePod(ctx, hugePod, placement)
+	if err != nil {
+		t.Fatalf("CanSchedulePod failed for hugePod after SyncSnapshot: %v", err)
+	}
+	if len(feasibleNodes) != 1 || feasibleNodes[0] != "node1" {
+		t.Errorf("Expected hugePod to fit on node1 after SyncSnapshot reverted mutations, got feasible nodes %v, diagnosis: %v", feasibleNodes, diag)
 	}
 }


### PR DESCRIPTION
Updating snapshot when there are simulated mutations is highly ambiguous in the expected behavior. The easiest solution is to revert mutations before updating the snapshot.

I've also slightly changed the contract for ClusterState.Snapshot. Now it's called `SyncSnapshot` and returns the same instance of the snapshot.

Ideally, we'd decouple the snapshot from ClusterState entirely and provide `UpdateSnapshot(ClusterSnapshot)`, but in case snapshot is updated by a different ClusterState than originally, it could break due to generation misalignment. We can already detect this case, but we can't handle it gracefully (i.e. rewrite the snapshot from scratch), as the logic for fresh rewrite is not exported: https://github.com/kubernetes/kubernetes/blob/b3bc2ac58fa173967f27ade80f28cc5015b8c1c3/pkg/scheduler/backend/cache/cache.go#L220. Creating a new instance of snapshot is also not an option, since we cannot swap the snapshot instance used by the framework.

Kueue intends to use multiple snapshots to run feasibility checks on cluster:
* without any pods
* without any non-tas pods
* with all pods

This could be achieved by running `Add/RemovePod` functions, but the concern is that the delta may be too big to be efficient.

Fixes #4
Fixes #9