### PR TITLE
Set up environment before running integration tests

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -14,6 +14,7 @@
 
 GO_CMD ?= go
 GOLANGCI_LINT := $(GO_CMD) tool golangci-lint
+SETUP_ENVTEST := $(GO_CMD) tool setup-envtest
 
 .PHONY: all
 all: build test lint
@@ -28,7 +29,7 @@ test:
 
 .PHONY: test-integration
 test-integration:
-	$(GO_CMD) test -v -race ./test/integration/...
+	PATH="$$($(SETUP_ENVTEST) use -p path):$${PATH}" $(GO_CMD) test -v -race ./test/integration/...
 
 .PHONY: fmt
 fmt:

--- a/go.mod
+++ b/go.mod
@@ -2,7 +2,10 @@ module sigs.k8s.io/scheduler-library
 
 go 1.26.0
 
-tool github.com/golangci/golangci-lint/v2/cmd/golangci-lint
+tool (
+	github.com/golangci/golangci-lint/v2/cmd/golangci-lint
+	sigs.k8s.io/controller-runtime/tools/setup-envtest
+)
 
 require (
 	github.com/google/go-cmp v0.7.0
@@ -97,6 +100,7 @@ require (
 	github.com/go-critic/go-critic v0.14.3 // indirect
 	github.com/go-logr/logr v1.4.3 // indirect
 	github.com/go-logr/stdr v1.2.2 // indirect
+	github.com/go-logr/zapr v1.3.0 // indirect
 	github.com/go-openapi/jsonpointer v0.22.4 // indirect
 	github.com/go-openapi/jsonreference v0.21.4 // indirect
 	github.com/go-openapi/swag v0.25.4 // indirect
@@ -326,6 +330,7 @@ require (
 	mvdan.cc/gofumpt v0.9.2 // indirect
 	mvdan.cc/unparam v0.0.0-20251027182757-5beb8c8f8f15 // indirect
 	sigs.k8s.io/apiserver-network-proxy/konnectivity-client v0.34.0 // indirect
+	sigs.k8s.io/controller-runtime/tools/setup-envtest v0.24.1 // indirect
 	sigs.k8s.io/json v0.0.0-20250730193827-2d320260d730 // indirect
 	sigs.k8s.io/randfill v1.0.0 // indirect
 	sigs.k8s.io/structured-merge-diff/v6 v6.4.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -860,6 +860,8 @@ mvdan.cc/unparam v0.0.0-20251027182757-5beb8c8f8f15 h1:ssMzja7PDPJV8FStj7hq9IKiu
 mvdan.cc/unparam v0.0.0-20251027182757-5beb8c8f8f15/go.mod h1:4M5MMXl2kW6fivUT6yRGpLLPNfuGtU2Z0cPvFquGDYU=
 sigs.k8s.io/apiserver-network-proxy/konnectivity-client v0.34.0 h1:hSfpvjjTQXQY2Fol2CS0QHMNs/WI1MOSGzCm1KhM5ec=
 sigs.k8s.io/apiserver-network-proxy/konnectivity-client v0.34.0/go.mod h1:Ve9uj1L+deCXFrPOk1LpFXqTg7LCFzFso6PA48q/XZw=
+sigs.k8s.io/controller-runtime/tools/setup-envtest v0.24.1 h1:l2AjyGE/PWub6EB165ij4/bpCK0TlY5NlhzIHfmGvmg=
+sigs.k8s.io/controller-runtime/tools/setup-envtest v0.24.1/go.mod h1:wpkYufRHTSw9ABET21/PkEL7kdGnmiZJ6o72t9p/1I8=
 sigs.k8s.io/json v0.0.0-20250730193827-2d320260d730 h1:IpInykpT6ceI+QxKBbEflcR5EXP7sU1kvOlxwZh5txg=
 sigs.k8s.io/json v0.0.0-20250730193827-2d320260d730/go.mod h1:mdzfpAEoE6DHQEN0uh9ZbOCuHbLK5wOm7dK4ctXE9Tg=
 sigs.k8s.io/randfill v1.0.0 h1:JfjMILfT8A6RbawdsK2JXGBR5AQVfd+9TbzrlneTyrU=


### PR DESCRIPTION
This should fix the error when running `make test-integration` in presubmits / environments where etcd is not installed.

`setup-envtest` seemed simpler. Alternatively I could add `install-etcd.sh` script, similar to https://github.com/kubernetes-sigs/scheduler-plugins/blob/master/hack/install-etcd.sh and https://github.com/kubernetes-sigs/scheduler-plugins/tree/master/hack/lib