### PR TITLE
snapshot: schedule copies instead of caller-owned Pods

### DIFF
--- a/pkg/simulator/simulator.go
+++ b/pkg/simulator/simulator.go
@@ -50,7 +50,8 @@ type Simulator interface {
 	// SchedulePods schedules the given pods one by one onto the placement and, unless opts.DryRun is
 	// set, keeps the result in the snapshot. The pods passed in are left untouched; the returned
 	// slice holds one result per attempted pod, each carrying a copy of the pod the attempt was made
-	// for, with the selected node set when it was scheduled.
+	// for, with the selected node set when it was scheduled. On a pod that was not scheduled
+	// Spec.NodeName is left as it came in, so it is empty unless the caller already set one.
 	SchedulePods(ctx context.Context, pods []*v1.Pod, placement *fwk.Placement, opts snapshot.SchedulePodsOptions) ([]snapshot.SchedulingResult, error)
 
 	// SchedulePodsByTemplate schedules as many pods created from the template as fit, up to maxPods.

--- a/pkg/simulator/simulator.go
+++ b/pkg/simulator/simulator.go
@@ -48,8 +48,9 @@ type Simulator interface {
 	CanSchedulePod(ctx context.Context, pod *v1.Pod, placement *fwk.Placement) ([]string, *schedFwk.Diagnosis, error)
 
 	// SchedulePods schedules the given pods one by one onto the placement and, unless opts.DryRun is
-	// set, keeps the result in the snapshot; every scheduled pod gets its Spec.NodeName set. The
-	// returned slice holds one result per attempted pod.
+	// set, keeps the result in the snapshot. The pods passed in are left untouched; the returned
+	// slice holds one result per attempted pod, each carrying a copy of the pod the attempt was made
+	// for, with the selected node set when it was scheduled.
 	SchedulePods(ctx context.Context, pods []*v1.Pod, placement *fwk.Placement, opts snapshot.SchedulePodsOptions) ([]snapshot.SchedulingResult, error)
 
 	// SchedulePodsByTemplate schedules as many pods created from the template as fit, up to maxPods.

--- a/pkg/upstreamsync/snapshot/snapshot.go
+++ b/pkg/upstreamsync/snapshot/snapshot.go
@@ -208,10 +208,24 @@ func schedulingResult(algRes *upstreamsync.AlgorithmResult) SchedulingResult {
 // StopOnFailure controls whether the first unschedulable pod stops the loop. Note that
 // All unexpected execution errors always propagate immediately regardless of StopOnFailure, as they
 // indicate a programming error rather than a scheduling failure.
-// Every pod that is scheduled gets its Spec.NodeName set to the selected node, which is also
-// reported by the corresponding SchedulingResult.
+// The pods passed in are left untouched. Each result carries the library's own copy of the pod the
+// attempt was made for, with Spec.NodeName set to the selected node when it was scheduled; that
+// copy is what PreemptPods takes to remove the pod again.
 func (s *ClusterSnapshot) SchedulePods(ctx context.Context, pods []*v1.Pod, placement *fwk.Placement, opts SchedulePodsOptions) ([]SchedulingResult, error) {
-	return s.schedulePods(ctx, slices.Values(pods), placement, opts)
+	return s.schedulePods(ctx, ownedCopies(pods), placement, opts)
+}
+
+// ownedCopies yields a copy of every pod, so that the simulation records the placement it made on a
+// pod of its own rather than on one the caller passed in and still owns. The pods generated from a
+// template need no such copy, as nothing outside the library holds them.
+func ownedCopies(pods []*v1.Pod) iter.Seq[*v1.Pod] {
+	return func(yield func(*v1.Pod) bool) {
+		for _, pod := range pods {
+			if !yield(pod.DeepCopy()) {
+				return
+			}
+		}
+	}
 }
 
 // SchedulePodsByTemplate attempts to schedule as many pods matching the template as possible.
@@ -273,8 +287,8 @@ func (s *ClusterSnapshot) schedulePods(ctx context.Context, pods iter.Seq[*v1.Po
 		}
 
 		if res.Status.IsSuccess() {
-			// Reflect the simulated placement on the caller's pod, so that a pod scheduled in this
-			// loop is seen as assigned by whoever inspects it, including the SchedulingResult below.
+			// The pods here are the library's own, so the placement is recorded on the pod itself
+			// and travels to the caller through the SchedulingResult below.
 			pod.Spec.NodeName = res.ScheduleResult.SuggestedHost
 		}
 

--- a/pkg/upstreamsync/snapshot/snapshot.go
+++ b/pkg/upstreamsync/snapshot/snapshot.go
@@ -210,7 +210,8 @@ func schedulingResult(algRes *upstreamsync.AlgorithmResult) SchedulingResult {
 // indicate a programming error rather than a scheduling failure.
 // The pods passed in are left untouched. Each result carries the library's own copy of the pod the
 // attempt was made for, with Spec.NodeName set to the selected node when it was scheduled; that
-// copy is what PreemptPods takes to remove the pod again.
+// copy is what PreemptPods takes to remove the pod again. On a pod that was not scheduled
+// Spec.NodeName is left as it came in, so it is empty unless the caller already set one.
 func (s *ClusterSnapshot) SchedulePods(ctx context.Context, pods []*v1.Pod, placement *fwk.Placement, opts SchedulePodsOptions) ([]SchedulingResult, error) {
 	return s.schedulePods(ctx, ownedCopies(pods), placement, opts)
 }
@@ -218,6 +219,8 @@ func (s *ClusterSnapshot) SchedulePods(ctx context.Context, pods []*v1.Pod, plac
 // ownedCopies yields a copy of every pod, so that the simulation records the placement it made on a
 // pod of its own rather than on one the caller passed in and still owns. The pods generated from a
 // template need no such copy, as nothing outside the library holds them.
+// The pods are copied one at a time rather than the whole slice up front, so a run that stops early
+// never copies the pods it does not attempt.
 func ownedCopies(pods []*v1.Pod) iter.Seq[*v1.Pod] {
 	return func(yield func(*v1.Pod) bool) {
 		for _, pod := range pods {
@@ -287,8 +290,9 @@ func (s *ClusterSnapshot) schedulePods(ctx context.Context, pods iter.Seq[*v1.Po
 		}
 
 		if res.Status.IsSuccess() {
-			// The pods here are the library's own, so the placement is recorded on the pod itself
-			// and travels to the caller through the SchedulingResult below.
+			// The pod object is a copy made within the simulation library. It is not modified by
+			// scheduleOnePod, but it is returned in the result object. To make the result placement
+			// visible to the caller, pod.Spec.NodeName needs to be set.
 			pod.Spec.NodeName = res.ScheduleResult.SuggestedHost
 		}
 

--- a/pkg/upstreamsync/snapshot/snapshot_test.go
+++ b/pkg/upstreamsync/snapshot/snapshot_test.go
@@ -342,6 +342,18 @@ func TestSnapshot_ActionSequences(t *testing.T) {
 			},
 		},
 		{
+			name:         "Dry-run rescheduling between preempt and unpreempt restores the original node",
+			assignedPods: map[string][]string{"node1": {"pod1"}, "singlePodNode": {}},
+			steps: []stepFn{
+				preempt("u1", "pod1"),
+				schedule([]string{"pod1"}, []string{"singlePodNode"}, NewSchedulePodsOptions(true, false)),
+				unpreempt("u1"),
+				verifySnapshot(map[string]sets.Set[string]{
+					"node1":         sets.New("pod1"),
+					"singlePodNode": sets.New[string]()}),
+			},
+		},
+		{
 			name:         "Preemption handle created in transaction fails to unpreempt in another transaction",
 			assignedPods: map[string][]string{"node1": {"pod1"}},
 			steps: []stepFn{
@@ -668,6 +680,13 @@ func TestSchedulePods(t *testing.T) {
 	pod3 := st.MakePod().Name("pod3").Namespace("default").UID("uid-pod3").Obj()
 	pod4 := st.MakePod().Name("pod4").Namespace("default").UID("uid-pod4").Obj()
 
+	// onNode is how a scheduled pod comes back: a copy carrying the node the attempt selected.
+	onNode := func(p *v1.Pod, nodeName string) *v1.Pod {
+		p = p.DeepCopy()
+		p.Spec.NodeName = nodeName
+		return p
+	}
+
 	tests := []struct {
 		name                string
 		nodes               []*v1.Node
@@ -686,7 +705,7 @@ func TestSchedulePods(t *testing.T) {
 			opts:           SchedulePodsOptions{},
 			expectResults: []SchedulingResult{
 				{
-					Pod:              pod1,
+					Pod:              onNode(pod1, "node1"),
 					SelectedNodeName: "node1",
 					Status:           fwk.NewStatus(fwk.Success),
 				},
@@ -701,7 +720,8 @@ func TestSchedulePods(t *testing.T) {
 			opts:           NewSchedulePodsOptions(true, false),
 			expectResults: []SchedulingResult{
 				{
-					Pod:              pod1,
+					// The dry run is reported like any other attempt; only the snapshot is restored.
+					Pod:              onNode(pod1, "node1"),
 					SelectedNodeName: "node1",
 					Status:           fwk.NewStatus(fwk.Success),
 				},
@@ -741,12 +761,12 @@ func TestSchedulePods(t *testing.T) {
 			opts:           NewSchedulePodsOptions(false, false),
 			expectResults: []SchedulingResult{
 				{
-					Pod:              pod1,
+					Pod:              onNode(pod1, "node1"),
 					Status:           fwk.NewStatus(fwk.Success),
 					SelectedNodeName: "node1",
 				},
 				{
-					Pod:              pod2,
+					Pod:              onNode(pod2, "node1"),
 					Status:           fwk.NewStatus(fwk.Success),
 					SelectedNodeName: "node1",
 				},
@@ -771,12 +791,12 @@ func TestSchedulePods(t *testing.T) {
 			opts:           NewSchedulePodsOptions(false, true),
 			expectResults: []SchedulingResult{
 				{
-					Pod:              pod1,
+					Pod:              onNode(pod1, "node1"),
 					Status:           fwk.NewStatus(fwk.Success),
 					SelectedNodeName: "node1",
 				},
 				{
-					Pod:              pod2,
+					Pod:              onNode(pod2, "node1"),
 					Status:           fwk.NewStatus(fwk.Success),
 					SelectedNodeName: "node1",
 				},
@@ -797,7 +817,7 @@ func TestSchedulePods(t *testing.T) {
 			opts:           NewSchedulePodsOptions(false, true),
 			expectResults: []SchedulingResult{
 				{
-					Pod:              pod1,
+					Pod:              onNode(pod1, "node1"),
 					SelectedNodeName: "node1",
 					Status:           fwk.NewStatus(fwk.Success),
 				},
@@ -817,7 +837,7 @@ func TestSchedulePods(t *testing.T) {
 			opts:           NewSchedulePodsOptions(false, true),
 			expectResults: []SchedulingResult{
 				{
-					Pod:              pod1,
+					Pod:              onNode(pod1, "node1"),
 					SelectedNodeName: "node1",
 					Status:           fwk.NewStatus(fwk.Success),
 				},
@@ -837,7 +857,7 @@ func TestSchedulePods(t *testing.T) {
 			opts:           SchedulePodsOptions{},
 			expectResults: []SchedulingResult{
 				{
-					Pod:              pod1,
+					Pod:              onNode(pod1, "node1"),
 					SelectedNodeName: "node1",
 					Status:           fwk.NewStatus(fwk.Success),
 				},
@@ -858,7 +878,13 @@ func TestSchedulePods(t *testing.T) {
 				t.Fatalf("MakePlacement() error = %v, expectErr %v", err, tc.expectErr)
 			}
 
-			results, err := cs.SchedulePods(ctx, tc.pods, placement, tc.opts)
+			// The fixtures are shared by the cases, so each one works on its own copies.
+			pods := make([]*v1.Pod, 0, len(tc.pods))
+			for _, p := range tc.pods {
+				pods = append(pods, p.DeepCopy())
+			}
+
+			results, err := cs.SchedulePods(ctx, pods, placement, tc.opts)
 			if (err != nil) != tc.expectErr {
 				t.Fatalf("SchedulePods() error = %v, expectErr %v", err, tc.expectErr)
 			}
@@ -867,7 +893,12 @@ func TestSchedulePods(t *testing.T) {
 				t.Errorf("Unexpected scheduling results (-want +got):\n%s", diff)
 			}
 
-			// SchedulePods reflects the selected node on the pods it was given.
+			// The pods belong to the caller, so the simulation must not write to them.
+			if diff := cmp.Diff(tc.pods, pods); diff != "" {
+				t.Errorf("SchedulePods mutated the pods it was given (-before +after):\n%s", diff)
+			}
+
+			// Successful results report the selected node on the Pod they return.
 			for _, res := range results {
 				if !res.Status.IsSuccess() {
 					continue
@@ -880,6 +911,31 @@ func TestSchedulePods(t *testing.T) {
 			ft.VerifySnapshot(t, snap, tc.expectSnapshotState)
 		})
 	}
+}
+
+// The pod handed to SchedulePods is not the one the snapshot ends up holding: the result carries
+// the copy that was placed, and that copy is what PreemptPods takes to remove it again.
+func TestSchedulePodsResultFeedsPreemptPods(t *testing.T) {
+	ctx := context.Background()
+	node := st.MakeNode().Name("node1").Capacity(map[v1.ResourceName]string{v1.ResourcePods: "1"}).Obj()
+	pod := st.MakePod().Name("pod1").Namespace("default").UID("uid-pod1").Obj()
+
+	cs, snap, _ := setupSnapshotTest(t, ctx, []*v1.Node{node}, nil)
+	placement, err := cs.MakePlacement([]string{"node1"})
+	if err != nil {
+		t.Fatalf("MakePlacement() error = %v", err)
+	}
+
+	results, err := cs.SchedulePods(ctx, []*v1.Pod{pod}, placement, SchedulePodsOptions{})
+	if err != nil {
+		t.Fatalf("SchedulePods() error = %v", err)
+	}
+	ft.VerifySnapshot(t, snap, map[string]sets.Set[string]{"node1": sets.New("pod1")})
+
+	if _, err := cs.PreemptPods(ctx, []*v1.Pod{results[0].Pod}); err != nil {
+		t.Fatalf("PreemptPods(results[0].Pod) error = %v", err)
+	}
+	ft.VerifySnapshot(t, snap, map[string]sets.Set[string]{"node1": sets.New[string]()})
 }
 
 func TestSchedulePodsByTemplate(t *testing.T) {

--- a/pkg/upstreamsync/snapshot/types.go
+++ b/pkg/upstreamsync/snapshot/types.go
@@ -72,8 +72,10 @@ const (
 
 // SchedulingResult is the outcome of a single pod scheduling attempt.
 type SchedulingResult struct {
-	// Pod is the pod the attempt was made for. For the pods created from a template it is the
-	// generated pod, which is the only way for the caller to learn what was scheduled.
+	// Pod is the pod the attempt was made for, carrying the selected node when it was scheduled.
+	// For the pods passed to SchedulePods it is the library's own copy; for the pods created from a
+	// template it is the generated pod, which is the only way for the caller to learn what was
+	// scheduled.
 	Pod *v1.Pod
 	// Status is the outcome of the scheduling cycle: success, or the reason the pod was rejected.
 	Status *fwk.Status

--- a/pkg/upstreamsync/snapshot/types.go
+++ b/pkg/upstreamsync/snapshot/types.go
@@ -76,6 +76,8 @@ type SchedulingResult struct {
 	// For the pods passed to SchedulePods it is the library's own copy; for the pods created from a
 	// template it is the generated pod, which is the only way for the caller to learn what was
 	// scheduled.
+	// On a failed attempt Spec.NodeName is left as it came in, so it is empty unless the caller, or
+	// the template, already set one.
 	Pod *v1.Pod
 	// Status is the outcome of the scheduling cycle: success, or the reason the pod was rejected.
 	Status *fwk.Status


### PR DESCRIPTION
Fixes #25

`SchedulePods` currently schedules the same Pod objects it receives and records the simulated placement on them. This change copies those Pods at the API boundary and schedules the copies instead, leaving the caller's objects untouched.

`SchedulingResult.Pod` carries the copy that was actually scheduled, with `Spec.NodeName` set to the selected node. `SelectedNodeName` is unchanged. `SchedulePodsByTemplate` is unchanged because its Pods are already created internally.

The scheduling loop and undo logic are unchanged. This also fixes the case where a dry run scheduling attempt between `PreemptPods` and `Unpreempt` could change the node used by the later undo.

### Behavior change

The Pod passed to `SchedulePods` no longer comes back with `Spec.NodeName` set.

For follow up operations on the scheduled Pod, such as `PreemptPods`, callers should use `SchedulingResult.Pod` instead. That is the Pod held by the snapshot and it carries the selected node.

### Tests

The tests cover the wrong node `Unpreempt` regression, the `SchedulePods` to `PreemptPods(results[0].Pod)` flow, and verify that `SchedulePods` leaves its input Pods unchanged.

The table tests also use per case Pod copies so shared fixtures and aliased expected results cannot hide input mutations.

> AI assistance was used for the analysis and drafting
